### PR TITLE
Fix 'aspiring' typo in About page

### DIFF
--- a/src/components/about/About.jsx
+++ b/src/components/about/About.jsx
@@ -57,7 +57,7 @@ return (
 
        <div className="aboutContent">
         {[
-          'Melissa Michaels is an author, reader, and aspirng novelist. Her love of writing grew out of her passion for reading, her tastes leaning towards Urban Fantasy.',
+          'Melissa Michaels is an author, reader, and aspiring novelist. Her love of writing grew out of her passion for reading, her tastes leaning towards Urban Fantasy.',
           'She is the author of <i>Ravens Transformation</i>, an Urban Fantasy short story featured in',
           'Abaculus III  a collection of international tales of science fiction, fantasy, and horror.',
           'Melissa is a proud member of the North Carolina Writers Network'


### PR DESCRIPTION
## Summary
- correct the typo in the About component so it reads "aspiring novelist"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*