### PR TITLE
Add server test framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,11 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "postcss": "^8.5.3",
+        "supertest": "^6.3.3",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.4.10",
-        "vite": "^5.4.10"
+        "vite": "^5.4.10",
+        "vitest": "^1.5.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
 
   "dependencies": {
@@ -34,6 +35,8 @@
     "vite": "^5.4.10",
     "tailwindcss": "^3.4.4",
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.3"
+    "postcss": "^8.5.3",
+    "supertest": "^6.3.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,4 +16,8 @@ app.set("views", path.join(__dirname, "src", "views"));
 app.get("/",      (_req, res) => res.render("index", { title: "Home"  }));
 app.get("/about", (_req, res) => res.render("about", { title: "About" }));
 
-app.listen(PORT, () => console.log(`🚀  http://localhost:${PORT}`));
+if (process.env.NODE_ENV !== "test") {
+  app.listen(PORT, () => console.log(`🚀  http://localhost:${PORT}`));
+}
+
+export { app };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import { app } from '../server.js';
+
+describe('server', () => {
+  it('GET / responds with 200', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add test script and dev deps
- export the Express app for testing
- add a simple supertest test

## Testing
- `npm test` *(fails: `vitest` not found)*