### PR TITLE
Add Vitest setup and simple mount test

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import App from './App.jsx';
+
+describe('App component', () => {
+  it('mounts without crashing', () => {
+    const { container } = render(<App />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- add a basic `<App />` mount test using React Testing Library
- configure vitest in `vite.config.js` to use jsdom and globals

## Testing
- `npm run test` *(fails: `vitest` not found)*