### PR TITLE
Clean up .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ dist-ssr
 node_modules/
 .DS_Store
 public/css/tailwind.css
- f740ab8c838717b11c086b5cba15389f9e6b6d46


### PR DESCRIPTION
## Summary
- remove stray commit hash from `.gitignore`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*