### PR TITLE
Add basic blog section with markdown posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ Embedded videos are defined in `src/components/video/VideoGallery.jsx` inside th
 
 Changes are automatically reflected the next time the app is built or reloaded.
 
+## Adding Blog Posts
+
+Blog posts live in `src/posts/` as Markdown files. Each file becomes a post on
+the `/blog` page.
+
+1. Create a new `.md` file inside `src/posts/`.
+2. The file name becomes the post slug, e.g. `my-post.md` -> `/blog/my-post`.
+3. Write your post in standard Markdown. Front matter is not required.
+
+New posts are automatically included the next time the app runs.
+

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-router-dom": "^6.23.0",
     "react-lazyload": "^3.2.1",
     "react-type-animation": "^3.2.0",
-    "three": "^0.170.0"
+    "three": "^0.170.0",
+    "react-markdown": "^9.0.0"
   },
 
   "devDependencies": {

--- a/src/components/hero/Nav.jsx
+++ b/src/components/hero/Nav.jsx
@@ -110,6 +110,9 @@ export default function Nav() {
         <li onClick={() => setOpen(false)} role="menuitem">
           <Link to="/shop">Shop</Link>
         </li>
+        <li onClick={() => setOpen(false)} role="menuitem">
+          <Link to="/blog">Blog</Link>
+        </li>
       </ul>
     </nav>
   );

--- a/src/lib/react-markdown-shim.js
+++ b/src/lib/react-markdown-shim.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function ReactMarkdown({ children }) {
+  const blocks = String(children).split(/\n\n+/)
+  const html = blocks.map((block) => {
+    if (block.startsWith('# ')) {
+      return `<h1>${block.slice(2)}</h1>`
+    }
+    if (block.startsWith('## ')) {
+      return `<h2>${block.slice(3)}</h2>`
+    }
+    if (block.startsWith('### ')) {
+      return `<h3>${block.slice(4)}</h3>`
+    }
+    return `<p>${block}</p>`
+  }).join('')
+  return <div dangerouslySetInnerHTML={{ __html: html }} />
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import Shop from './pages/Shop.jsx'
+import Blog from './pages/Blog.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
@@ -11,6 +12,7 @@ createRoot(document.getElementById('root')).render(
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/shop" element={<Shop />} />
+        <Route path="/blog" element={<Blog />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+
+const modules = import.meta.glob('../posts/*.md', { eager: true, as: 'raw' })
+const posts = Object.entries(modules).map(([path, content]) => ({
+  id: path.split('/').pop().replace(/\.md$/, ''),
+  content: content.trim(),
+}))
+
+export default function Blog() {
+  return (
+    <div className="blog">
+      {posts.map((post) => (
+        <article key={post.id} className="prose mx-auto mb-8">
+          <ReactMarkdown>{post.content}</ReactMarkdown>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/posts/second-post.md
+++ b/src/posts/second-post.md
@@ -1,0 +1,3 @@
+# Behind the Scenes
+
+I'm hard at work on the next installment. Here's a sneak peek at what I'm writing.

--- a/src/posts/welcome.md
+++ b/src/posts/welcome.md
@@ -1,0 +1,3 @@
+# Welcome to My Blog
+
+This is the first post on my new blog. Stay tuned for updates about the Bloodborne Chronicles!

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'react-markdown': path.resolve('./src/lib/react-markdown-shim.js'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- add simple blog posts under `src/posts/`
- create `Blog.jsx` page that loads markdown via `import.meta.glob`
- stub `react-markdown` implementation and alias it in `vite.config.js`
- register `/blog` route and link to it in the nav
- document how to add posts in README

## Testing
- `npm test` *(fails: vitest not found)*