### PR TITLE
Enable JSX for JS files

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,17 @@ import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      // enable React refresh and JSX transform in .js files
+      include: /\.jsx?$/,
+    }),
+  ],
+  esbuild: {
+    // treat .js files as having JSX syntax
+    loader: 'jsx',
+    include: /src\/.*\.js$/,
+  },
   resolve: {
     alias: {
       'react-markdown': path.resolve('./src/lib/react-markdown-shim.js'),


### PR DESCRIPTION
## Summary
- adjust Vite config so `.js` files are processed with JSX
- configure esbuild loader to treat `.js` as JSX

## Testing
- `npm test` *(fails: vitest not found)*