### PR TITLE
Fix invalid JS syntax in main.jsx

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,5 +15,5 @@ createRoot(document.getElementById('root')).render(
         <Route path="/blog" element={<Blog />} />
       </Routes>
     </BrowserRouter>
-  </StrictMode>,
+  </StrictMode>
 )


### PR DESCRIPTION
## Summary
- fix syntax error in main.jsx

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*