### PR TITLE
Add basic blog metadata and single post pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,22 @@ Changes are automatically reflected the next time the app is built or reloaded.
 ## Adding Blog Posts
 
 Blog posts live in `src/posts/` as Markdown files. Each file becomes a post on
-the `/blog` page.
+the `/blog` page and can be viewed individually at `/blog/<slug>`.
 
 1. Create a new `.md` file inside `src/posts/`.
-2. The file name becomes the post slug, e.g. `my-post.md` -> `/blog/my-post`.
-3. Write your post in standard Markdown. Front matter is not required.
+2. Add a YAML front matter block with at least `title`, `date`, and `summary`.
+   Example:
+
+   ```markdown
+   ---
+   title: "My Post"
+   date: "2024-01-01"
+   summary: "A short summary"
+   ---
+   ```
+
+3. The file name becomes the post slug, e.g. `my-post.md` -> `/blog/my-post`.
+4. Write the rest of your post in standard Markdown.
 
 New posts are automatically included the next time the app runs.
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import './index.css'
 import App from './App.jsx'
 import Shop from './pages/Shop.jsx'
 import Blog from './pages/Blog.jsx'
+import Post from './pages/Post.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
@@ -13,6 +14,7 @@ createRoot(document.getElementById('root')).render(
         <Route path="/" element={<App />} />
         <Route path="/shop" element={<Shop />} />
         <Route path="/blog" element={<Blog />} />
+        <Route path="/blog/:slug" element={<Post />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,18 +1,23 @@
 import React from 'react'
-import ReactMarkdown from 'react-markdown'
+import { Link } from 'react-router-dom'
+import matter from 'gray-matter'
 
 const modules = import.meta.glob('../posts/*.md', { eager: true, as: 'raw' })
-const posts = Object.entries(modules).map(([path, content]) => ({
-  id: path.split('/').pop().replace(/\.md$/, ''),
-  content: content.trim(),
-}))
+const posts = Object.entries(modules).map(([path, content]) => {
+  const slug = path.split('/').pop().replace(/\.md$/, '')
+  const { data } = matter(content)
+  return { slug, ...data }
+}).sort((a, b) => new Date(b.date) - new Date(a.date))
 
 export default function Blog() {
   return (
     <div className="blog">
       {posts.map((post) => (
-        <article key={post.id} className="prose mx-auto mb-8">
-          <ReactMarkdown>{post.content}</ReactMarkdown>
+        <article key={post.slug} className="prose mx-auto mb-8">
+          <h2>
+            <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+          </h2>
+          <p>{post.summary}</p>
         </article>
       ))}
     </div>

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import matter from 'gray-matter'
+
+const modules = import.meta.glob('../posts/*.md', { eager: true, as: 'raw' })
+const posts = Object.entries(modules).map(([path, content]) => {
+  const slug = path.split('/').pop().replace(/\.md$/, '')
+  const { data, content: body } = matter(content)
+  return { slug, ...data, body }
+})
+
+export default function Post() {
+  const { slug } = useParams()
+  const post = posts.find((p) => p.slug === slug)
+  if (!post) {
+    return <div className="prose mx-auto">Post not found.</div>
+  }
+  return (
+    <article className="prose mx-auto">
+      <h1>{post.title}</h1>
+      <ReactMarkdown>{post.body}</ReactMarkdown>
+    </article>
+  )
+}

--- a/src/posts/second-post.md
+++ b/src/posts/second-post.md
@@ -1,3 +1,9 @@
+---
+title: "Behind the Scenes"
+date: "2023-02-15"
+summary: "A preview of upcoming work"
+---
+
 # Behind the Scenes
 
 I'm hard at work on the next installment. Here's a sneak peek at what I'm writing.

--- a/src/posts/welcome.md
+++ b/src/posts/welcome.md
@@ -1,3 +1,9 @@
+---
+title: "Welcome to My Blog"
+date: "2023-01-01"
+summary: "Introducing my new blog"
+---
+
 # Welcome to My Blog
 
 This is the first post on my new blog. Stay tuned for updates about the Bloodborne Chronicles!


### PR DESCRIPTION
## Summary
- parse markdown front matter for blog posts
- list posts on the blog page with links
- add page to render individual posts
- document how to add posts with front matter

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*
- `npm run lint` *(fails: Key "languageOptions" config error)*