### PR TITLE
Add layout wrapper and polish blog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ const Hero = lazy(() => import("./components/hero/Hero"));
 const Services = lazy(() => import("./components/books/BookPreview"));
 const About = lazy(() => import("./components/about/About"));
 const Newsletter = lazy(() => import("./components/newsletter/Newsletter"));
-const Footer = lazy(() => import("./components/footer/Footer"));
 
 const App = () => (
   <main id="main" className="container">
@@ -48,9 +47,6 @@ const App = () => (
       </LazyLoad>
     </Suspense>
 
-    <Suspense fallback={null}>
-      <Footer />
-    </Suspense>
   </main>
 );
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Outlet } from 'react-router-dom'
+import Nav from './hero/Nav'
+import Footer from './footer/Footer'
+
+export default function Layout() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Nav />
+      <div className="flex-1 pt-16">
+        <Outlet />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -2,7 +2,6 @@
 import React, { Suspense } from "react";
 import { Canvas } from "@react-three/fiber";
 import { motion } from "motion/react";
-import Nav from "./Nav";
 import Shape from "./Shape";
 import NewsletterCta from "./NewsletterCta";
 import "./hero.css";
@@ -15,8 +14,6 @@ export default function Hero() {
 
   return (
     <>
-      <Nav />
-
       <section id="home" className="hero">
         <div className="hSection left">
           <motion.h1

--- a/src/components/hero/Nav.jsx
+++ b/src/components/hero/Nav.jsx
@@ -1,7 +1,7 @@
 // src/components/hero/Nav.jsx
 
 import React, { useState, useEffect, useCallback } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import "./hero.css";
 
 const sections = [
@@ -12,23 +12,34 @@ const sections = [
 
 export default function Nav() {
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const goTo = useCallback((id) => {
+  const scrollTo = useCallback((id) => {
     const el = document.getElementById(id);
     if (el) {
       el.scrollIntoView({ behavior: "smooth" });
-    } else {
-      window.location.hash = id;
     }
-    setOpen(false);
   }, []);
 
+  const goTo = useCallback(
+    (id) => {
+      if (location.pathname !== "/") {
+        navigate(`/#${id}`);
+      } else {
+        scrollTo(id);
+      }
+      setOpen(false);
+    },
+    [location.pathname, navigate, scrollTo]
+  );
+
   useEffect(() => {
-    const hash = window.location.hash.slice(1);
+    const hash = location.hash.slice(1);
     if (hash) {
-      setTimeout(() => goTo(hash), 50);
+      setTimeout(() => scrollTo(hash), 50);
     }
-  }, [goTo]);
+  }, [location, scrollTo]);
 
   return (
     <nav className="nav">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import Layout from './components/Layout.jsx'
 const Shop = lazy(() => import('./pages/Shop.jsx'))
 const Blog = lazy(() => import('./pages/Blog.jsx'))
 const Post = lazy(() => import('./pages/Post.jsx'))
@@ -12,10 +13,12 @@ createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <Suspense fallback={null}>
         <Routes>
-          <Route path="/" element={<App />} />
-          <Route path="/shop" element={<Shop />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/blog/:slug" element={<Post />} />
+          <Route element={<Layout />}>
+            <Route index element={<App />} />
+            <Route path="shop" element={<Shop />} />
+            <Route path="blog" element={<Blog />} />
+            <Route path="blog/:slug" element={<Post />} />
+          </Route>
         </Routes>
       </Suspense>
     </BrowserRouter>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import matter from 'gray-matter'
+import { Buffer } from 'buffer'
 
-const modules = import.meta.glob('../posts/*.md', { as: 'raw' })
+const modules = import.meta.glob('../posts/*.md', { query: '?raw', import: 'default' })
+window.Buffer = window.Buffer || Buffer
 
 async function loadPosts() {
   const entries = await Promise.all(
@@ -24,12 +26,18 @@ export default function Blog() {
   }, [])
 
   return (
-    <div className="blog">
+    <div className="container py-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {posts.map((post) => (
-        <article key={post.slug} className="prose mx-auto mb-8">
-          <h2>
+        <article
+          key={post.slug}
+          className="bg-black/40 p-6 rounded shadow hover:shadow-lg hover:-translate-y-1 transition"
+        >
+          <h2 className="text-xl mb-2">
             <Link to={`/blog/${post.slug}`}>{post.title}</Link>
           </h2>
+          <p className="text-sm opacity-75 mb-4">
+            {new Date(post.date).toLocaleDateString()}
+          </p>
           <p>{post.summary}</p>
         </article>
       ))}

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -2,8 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import matter from 'gray-matter'
+import { Buffer } from 'buffer'
 
-const modules = import.meta.glob('../posts/*.md', { as: 'raw' })
+const modules = import.meta.glob('../posts/*.md', { query: '?raw', import: 'default' })
+window.Buffer = window.Buffer || Buffer
 
 async function loadPost(slug) {
   const loader = modules[`../posts/${slug}.md`]
@@ -30,7 +32,7 @@ export default function Post() {
   }
 
   return (
-    <article className="prose mx-auto">
+    <article className="prose mx-auto p-4 bg-black/40 rounded">
       <h1>{post.title}</h1>
       <ReactMarkdown>{post.body}</ReactMarkdown>
     </article>

--- a/src/pages/Shop.jsx
+++ b/src/pages/Shop.jsx
@@ -1,9 +1,6 @@
-import Nav from "../components/hero/Nav";
-
 export default function Shop() {
   return (
     <div className="container shop-page">
-      <Nav />
       <main className="shop-content">
         <h1>Coming Soon!</h1>
         <p>The merchandise shop is currently under construction. Check back soon for updates!</p>


### PR DESCRIPTION
## Summary
- implement a shared `Layout` component with global navigation and footer
- upgrade navigation logic for cross-route scrolling
- enhance markdown blog rendering and styling
- apply Vite's updated glob syntax and Buffer polyfill
- wrap routes with `Layout` and remove redundant nav imports

## Testing
- `npm test` *(fails: MISSING DEPENDENCY jsdom)*