### PR TITLE
Update hero CTA and about blurb

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ const App = () => (
       <LazyLoad height="600vh" offset={-100}>
         <section id="about">
           <About
+            headshot="/p1.png"
             bio={[
               'Melissa Michaels is an author, reader, and aspiring novelist. Her love of writing grew out of her passion for reading, her tastes leaning towards Urban Fantasy.',
               'She is the author of <i>Ravens Transformation</i>, an Urban Fantasy short story featured in Abaculus III, a collection of international tales of science fiction, fantasy, and horror.',

--- a/src/components/books/BookPreview.jsx
+++ b/src/components/books/BookPreview.jsx
@@ -10,7 +10,7 @@ export default function BookPreview() {
         <div className="preview-description">
           <h2 className="preview-title">Raven's Revenge</h2>
           <p>
-            Launching the <em>Bloodborne Chronicles</em>—a dark tale of magic and retribution.
+            Raven's Revenge kicks off the <em>Bloodborne Chronicles</em> with a gripping tale of sorcery and payback.
           </p>
         </div>
       </div>

--- a/src/components/hero/NewsletterCta.jsx
+++ b/src/components/hero/NewsletterCta.jsx
@@ -7,12 +7,6 @@ const slideIn = {
     animate: { x: 0, opacity: 1, transition: { duration: 2 } },
 };
 
-const spin = {
-    animate: {
-        rotate: [0, 360],
-        transition: { duration: 10, repeat: Infinity, ease: "linear" },
-    },
-};
 
 export default function NewsletterCta({ href = "#contact" }) {
     return (
@@ -23,9 +17,13 @@ export default function NewsletterCta({ href = "#contact" }) {
             animate="animate"
             className="contactLink"
         >
-            <motion.div className="contactButton" variants={spin}>
+        <motion.div
+            className="contactButton"
+            whileHover={{ rotate: 360 }}
+            transition={{ duration: 2, ease: "linear" }}
+        >
                 <svg viewBox="0 0 200 200" width="150" height="150">
-                    <circle cx="100" cy="100" r="90" fill="#d23d3d" />
+                    <circle cx="100" cy="100" r="90" fill="var(--blood-red)" />
                     <path
                         id="innerCirclePath"
                         fill="none"

--- a/src/components/hero/hero.css
+++ b/src/components/hero/hero.css
@@ -121,6 +121,14 @@
   box-shadow: var(--shadow-md);
 }
 
+.contactLink {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  text-decoration: none;
+  z-index: 50;
+}
+
 .hImg {
   position: absolute;
   inset: 0;

--- a/src/components/newsletter/Newsletter.jsx
+++ b/src/components/newsletter/Newsletter.jsx
@@ -2,7 +2,6 @@ import "./newsletter.css";
 import emailjs from "@emailjs/browser";
 import { useRef, useState } from "react";
 import { motion, useInView } from "motion/react";
-import ContactSvg from "./ContactSvg";
 
 const listVariant = {
   initial: {
@@ -92,7 +91,6 @@ const Contact = () => {
           {error && <span>Something went wrong!</span>}
         </motion.form>
       </div>
-      <div className="cSection"><ContactSvg/></div>
     </div>
   );
 };

--- a/src/components/newsletter/newsletter.css
+++ b/src/components/newsletter/newsletter.css
@@ -1,24 +1,20 @@
+
 .contact {
   height: 100%;
   display: flex;
-  gap: 100px;
+  justify-content: center;
+  padding: 20px;
 }
 
 .cSection {
-  width: 50%;
-  height: 100%;
+  width: 100%;
+  max-width: 600px;
   padding: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.cSection:last-child {
-  background-color: rgba(2, 2, 45, 0.187);
-  margin: 50px 0px;
-  padding: 50px;
-  border-radius: 50% 0px;
-}
 
 form {
   width: 80%;
@@ -75,12 +71,5 @@ label {
 
   .cSection {
     width: 100%;
-  }
-
-  .cSection:first-child {
-    height: 70%;
-  }
-  .cSection:last-child {
-    height: 30%;
   }
 }


### PR DESCRIPTION
## Summary
- tweak the rotating newsletter CTA so it only spins on hover
- reposition CTA with new styles
- update Raven's Revenge blurb
- show author headshot in About section
- remove unused contact SVG and simplify newsletter styles

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*