### PR TITLE
Remove Buy Now buttons from previews

### DIFF
--- a/src/components/books/BookCarousel.jsx
+++ b/src/components/books/BookCarousel.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+// Books are not yet for sale; disable purchase actions for now.
+const isAvailable = false;
+
 const books = [
   { id: 1, title: "Raven's Revenge", cover: '/RR_Cover.jpg' },
   { id: 2, title: 'Abaculus III', cover: '/Abaculus.jpg' },
@@ -12,7 +15,21 @@ export default function BookCarousel() {
         <div key={b.id} className="snap-center shrink-0 w-48 text-center">
           <img src={b.cover} alt={b.title} className="mb-2 rounded shadow" />
           <p className="font-display text-lg">{b.title}</p>
-          <button className="mt-2 px-3 py-1 bg-red-800 text-white rounded transition-colors hover:bg-red-700">Buy Now</button>
+          {isAvailable ? (
+            <button
+              className="mt-2 px-3 py-1 bg-red-800 text-white rounded transition-colors hover:bg-red-700"
+              aria-label={`Purchase ${b.title}`}
+            >
+              Buy Now
+            </button>
+          ) : (
+            <span
+              className="mt-2 inline-block px-3 py-1 bg-gray-500 text-white rounded"
+              aria-label="Upcoming release"
+            >
+              Coming Soon
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/books/BookPreview.jsx
+++ b/src/components/books/BookPreview.jsx
@@ -3,6 +3,9 @@ import BookModelContainer from "./computer/BookModelContainer";
 import BookCarousel from "./BookCarousel";
 import "./book-preview.css";
 
+// Purchase controls are disabled until the book is officially released.
+const isAvailable = false;
+
 export default function BookPreview() {
   return (
     <section className="book-preview container mx-auto py-12">
@@ -13,9 +16,21 @@ export default function BookPreview() {
           <p>
             Raven's Revenge kicks off the <em>Bloodborne Chronicles</em> with a gripping tale of sorcery and payback.
           </p>
-          <button className="mt-4 px-4 py-2 bg-red-800 text-white rounded hover:bg-red-700 transition-colors">
-            Buy Now
-          </button>
+          {isAvailable ? (
+            <button
+              className="mt-4 px-4 py-2 bg-red-800 text-white rounded hover:bg-red-700 transition-colors"
+              aria-label="Purchase Raven's Revenge"
+            >
+              Buy Now
+            </button>
+          ) : (
+            <span
+              className="mt-4 inline-block px-4 py-2 bg-gray-500 text-white rounded"
+              aria-label="Upcoming release"
+            >
+              Coming Soon
+            </span>
+          )}
         </div>
       </div>
       <BookCarousel />


### PR DESCRIPTION
## Summary
- hide purchase CTAs for unreleased books
- note upcoming release instead of sales buttons

## Testing
- `npm test`
- `npm run dev` *(manually exited)*