### PR TITLE
Refactor homepage into scrollytelling guide

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,66 +1,146 @@
-import React, { lazy, Suspense } from "react";
+import React, { lazy, Suspense, useMemo, useState } from "react";
+import { useReducedMotion } from "motion/react";
 import SEO from './components/utility/SEO';
-import LazyLoad from "react-lazyload";
+import Chapter from "./components/scrollytelling/Chapter";
+import ProgressIndicator from "./components/scrollytelling/ProgressIndicator";
+import IntroGate from "./components/scrollytelling/IntroGate";
+import NoteModal from "./components/scrollytelling/NoteModal";
 
 const Hero = lazy(() => import("./components/hero/Hero"));
 const Services = lazy(() => import("./components/books/BookPreview"));
 const About = lazy(() => import("./components/about/About"));
 const Newsletter = lazy(() => import("./components/newsletter/Newsletter"));
+const ImmersiveScene = lazy(() => import("./components/scrollytelling/ImmersiveScene"));
 
 // Main homepage component with your original structure
-const App = () => (
-  <main id="main" className="container">
-    <SEO title="Melissa Michaels" description="Urban fantasy author" />
-    <Suspense fallback={null}>
-      <LazyLoad height="100vh" offset={-100}>
-        <section id="home">
-          <Hero />
-        </section>
-      </LazyLoad>
-    </Suspense>
+const App = () => {
+  const [hasEntered, setHasEntered] = useState(false);
+  const [noteOpen, setNoteOpen] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
 
-    <Suspense fallback={null}>
-      <LazyLoad height="100vh" offset={-100}>
-        <section id="services">
-          <Services />
-        </section>
-      </LazyLoad>
-    </Suspense>
+  const chapters = useMemo(() => ([
+    { id: "home", number: "01", label: "Arrival" },
+    { id: "services", number: "02", label: "Preview" },
+    { id: "about", number: "03", label: "Author" },
+    { id: "immersive", number: "04", label: "Immersion" },
+    { id: "contact", number: "05", label: "Contact" },
+  ]), []);
 
-    <Suspense fallback={<div>Loading...</div>}>
-      <LazyLoad height="600vh" offset={-100} once>
-        <section id="about">
-          <About
-            headshot="/aboutme.jpg"
-            bio={[
-              `Some stories find you in the static between frequencies, in the three frames of thermal 
-          where something moves too fast to be human. Melissa Michaels writes at the intersection 
-          of ancient bloodlines and modern warfare, where drones track shadows that shouldn't exist 
-          and family curses download like malware into military-grade systems.`,
-          
-          `The Bloodborne Chronicles emerged from late-night gaming sessions and hiking trails where 
-          Caesar, her German Shepherd, would freeze at sounds only he could hear. Her protagonist 
-          Raven Andros sees the world in heat signatures and extraction points—until the day the 
-          geometry breaks and something older than surveillance satellites starts hunting back.`,
-          
-          `<em>Raven's Transformation</em>, featured in literary journal <em>Abaculus</em>, introduced 
-          readers to a world where mandatory leave feels like a death sentence and going home means 
-          confronting shadows that point the wrong direction at sunset.`
-            ]}
-            blurb="More stories and updates coming soon."
-          />
-        </section>
-      </LazyLoad>
-    </Suspense>
+  const shouldShowImmersive = useMemo(() => {
+    if (prefersReducedMotion) return false;
+    if (typeof window === "undefined") return true;
+    const lowMemory = navigator.deviceMemory && navigator.deviceMemory < 4;
+    const lowCores = navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4;
+    const isSmallScreen = window.matchMedia
+      ? window.matchMedia("(max-width: 900px)").matches
+      : false;
+    return !(lowMemory || lowCores || isSmallScreen);
+  }, [prefersReducedMotion]);
 
-    <Suspense fallback={null}>
-      <LazyLoad height="100vh" offset={-100}>
-        <section id="contact">
-          <Newsletter />
-        </section>
-      </LazyLoad>
-    </Suspense>
-  </main>
-);
+  return (
+    <main id="main" className="scrolly-shell">
+      <SEO title="Melissa Michaels" description="Urban fantasy author" />
+      <IntroGate
+        isOpen={!hasEntered}
+        onEnter={() => setHasEntered(true)}
+        onOpenNote={() => setNoteOpen(true)}
+      />
+      <NoteModal isOpen={noteOpen} onClose={() => setNoteOpen(false)} />
+
+      {hasEntered && <ProgressIndicator chapters={chapters} />}
+
+      <div className="scrolly-track" aria-hidden={!hasEntered}>
+        <Suspense fallback={null}>
+          <Chapter
+            id="home"
+            number="01"
+            title="Bloodborne signal"
+            statement="A scrollytelling guide into Melissa Michaels’ urban fantasy worlds."
+            body="Follow the tension between surveillance tech, ancient bloodlines, and the ghosts that move just outside the frame."
+            align="right"
+          >
+            <Hero as="div" id={null} />
+          </Chapter>
+        </Suspense>
+
+        <Suspense fallback={null}>
+          <Chapter
+            id="services"
+            number="02"
+            title="Preview the latest"
+            statement="Step into Raven Andros’ first encounter."
+            body="A tactical operative meets a supernatural anomaly that breaks every rule she trusts."
+          >
+            <Services as="div" />
+          </Chapter>
+        </Suspense>
+
+        <Suspense fallback={<div className="chapter-loading">Loading author bio...</div>}>
+          <Chapter
+            id="about"
+            number="03"
+            title="Behind the bloodline"
+            statement="The author’s signal, decoded."
+            body="Follow the threads that shape the Bloodborne Chronicles and the worlds they inhabit."
+            align="right"
+          >
+            <About
+              as="div"
+              id={null}
+              headshot="/aboutme.jpg"
+              bio={[
+                `Some stories find you in the static between frequencies, in the three frames of thermal 
+            where something moves too fast to be human. Melissa Michaels writes at the intersection 
+            of ancient bloodlines and modern warfare, where drones track shadows that shouldn't exist 
+            and family curses download like malware into military-grade systems.`,
+            
+            `The Bloodborne Chronicles emerged from late-night gaming sessions and hiking trails where 
+            Caesar, her German Shepherd, would freeze at sounds only he could hear. Her protagonist 
+            Raven Andros sees the world in heat signatures and extraction points—until the day the 
+            geometry breaks and something older than surveillance satellites starts hunting back.`,
+            
+            `<em>Raven's Transformation</em>, featured in literary journal <em>Abaculus</em>, introduced 
+            readers to a world where mandatory leave feels like a death sentence and going home means 
+            confronting shadows that point the wrong direction at sunset.`
+              ]}
+              blurb="More stories and updates coming soon."
+            />
+          </Chapter>
+        </Suspense>
+
+        <Chapter
+          id="immersive"
+          number="04"
+          title="Immersive layer"
+          statement="A reserved slot for a future cinematic scene."
+          body="This placeholder is ready for a lightweight WebGL or 3D moment when you’re ready to add it."
+        >
+          {shouldShowImmersive ? (
+            <Suspense fallback={<div className="chapter-loading">Loading immersive layer...</div>}>
+              <ImmersiveScene />
+            </Suspense>
+          ) : (
+            <div className="immersive-placeholder" role="note">
+              Immersive mode is paused on this device for performance.
+            </div>
+          )}
+        </Chapter>
+
+        <Suspense fallback={null}>
+          <Chapter
+            id="contact"
+            number="05"
+            title="Stay in the signal"
+            statement="Join the reader list for new releases."
+            body="Short dispatches, release alerts, and behind-the-scenes notes from the Bloodborne Chronicles."
+            align="right"
+          >
+            <Newsletter />
+          </Chapter>
+        </Suspense>
+      </div>
+    </main>
+  );
+};
 
 export default App;

--- a/src/components/about/About.jsx
+++ b/src/components/about/About.jsx
@@ -127,6 +127,8 @@ const SocialIcons = {
  * @returns {JSX.Element} A motion-enhanced section element displaying the author's details.
  */
 export default function About({ 
+  as: Wrapper = "section",
+  id = "about",
   headshot, 
   bio = [], 
   blurb, 
@@ -190,14 +192,16 @@ export default function About({
     );
   }, [variants.link, authorName]);
 
+  const wrapperProps = {
+    className: "about",
+    ref,
+    "aria-labelledby": "about-title",
+    role: "region",
+    ...(id ? { id } : {}),
+  };
+
   return (
-    <section
-      id="about"
-      className="about"
-      ref={ref}
-      aria-labelledby="about-title"
-      role="region"
-    >
+    <Wrapper {...wrapperProps}>
       <motion.div
         className="about_progress"
         style={{ scaleX: progress }}
@@ -276,6 +280,6 @@ export default function About({
         {renderSocialLink('Facebook', processedSocialLinks.facebook, SocialIcons.Facebook)}
         {renderSocialLink('Twitter', processedSocialLinks.twitter, SocialIcons.Twitter)}
       </motion.nav>
-    </section>
+    </Wrapper>
   );
 }

--- a/src/components/books/BookPreview.jsx
+++ b/src/components/books/BookPreview.jsx
@@ -4,7 +4,7 @@ import { createPortal } from "react-dom";
 import BookModelContainer from "./computer/BookModelContainer";
 import "./book-preview.css";
 
-export default function BookPreview() {
+export default function BookPreview({ as: Wrapper = "section", id }) {
   const [showModal, setShowModal] = useState(false);
   const [modelLoaded, setModelLoaded] = useState(false);
 
@@ -66,7 +66,11 @@ export default function BookPreview() {
 
   return (
     <>
-      <section className="book-preview" aria-label="Book preview section">
+      <Wrapper
+        className="book-preview"
+        aria-label="Book preview section"
+        {...(id ? { id } : {})}
+      >
         <div className="preview-content">
           <div className="book-model-wrapper">
             <BookModelContainer onLoad={() => setModelLoaded(true)} />
@@ -89,7 +93,7 @@ export default function BookPreview() {
             </button>
           </div>
         </div>
-      </section>
+      </Wrapper>
 
       {showModal &&
         createPortal(

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -30,7 +30,7 @@ const ScrollIcon = () => (
   </svg>
 );
 
-export default function Hero() {
+export default function Hero({ as: Wrapper = "section", id = "home" }) {
   const prefersReducedMotion = useReducedMotion();
   
   const scrollToTop = useCallback(() => {
@@ -102,9 +102,14 @@ export default function Hero() {
     tap: prefersReducedMotion ? {} : { scale: 0.95 }
   }), [prefersReducedMotion]);
 
+  const wrapperProps = {
+    className: "hero",
+    ...(id ? { id } : {}),
+  };
+
   return (
     <>
-      <section id="home" className="hero">
+      <Wrapper {...wrapperProps}>
         <header className="hSection left">
           <motion.h1
             {...titleVariants}
@@ -191,7 +196,7 @@ export default function Hero() {
             <path d="M20 30V10M10 20l10-10 10 10" />
           </svg>
         </motion.button>
-      </section>
+      </Wrapper>
 
       <NewsletterModal />
     </>

--- a/src/components/scrollytelling/Chapter.jsx
+++ b/src/components/scrollytelling/Chapter.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+export default function Chapter({
+  id,
+  number,
+  title,
+  statement,
+  body,
+  align = "left",
+  children,
+}) {
+  const prefersReducedMotion = useReducedMotion();
+  const ref = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setIsVisible(true);
+      return;
+    }
+
+    const element = ref.current;
+    if (!element) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        }
+      },
+      { threshold: 0.25 }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [prefersReducedMotion]);
+
+  const bodyMarkup = useMemo(() => {
+    if (!body) return null;
+    if (Array.isArray(body)) {
+      return body.map((line, index) => <p key={`${id}-body-${index}`}>{line}</p>);
+    }
+    return <p>{body}</p>;
+  }, [body, id]);
+
+  return (
+    <section
+      id={id}
+      ref={ref}
+      className={`scrolly-chapter scrolly-chapter--${align}${isVisible ? " is-visible" : ""}`}
+      data-chapter={number}
+      aria-labelledby={`${id}-title`}
+    >
+      <div className="chapter-grid">
+        <div className="chapter-meta">
+          <span className="chapter-number">{number}</span>
+          <h2 id={`${id}-title`} className="chapter-title">
+            {title}
+          </h2>
+          {statement && <p className="chapter-statement">{statement}</p>}
+          {bodyMarkup}
+        </div>
+        <div className="chapter-media">{children}</div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/scrollytelling/ImmersiveScene.jsx
+++ b/src/components/scrollytelling/ImmersiveScene.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function ImmersiveScene() {
+  return (
+    <div className="immersive-scene" role="img" aria-label="Immersive scene placeholder">
+      <div className="immersive-frame">
+        <p className="immersive-title">Immersive Scene Placeholder</p>
+        <p className="immersive-body">
+          TODO: Replace this block with a lightweight WebGL/3D scene that mirrors
+          the Bloodborne Chronicles atmosphere without blocking page performance.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scrollytelling/IntroGate.jsx
+++ b/src/components/scrollytelling/IntroGate.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from "react";
+
+export default function IntroGate({ isOpen, onEnter, onOpenNote }) {
+  const enterRef = useRef(null);
+  const gateRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      document.body.style.overflow = "unset";
+      return;
+    }
+
+    document.body.style.overflow = "hidden";
+    if (enterRef.current) {
+      enterRef.current.focus();
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key !== "Tab" || !gateRef.current) return;
+      const focusable = gateRef.current.querySelectorAll(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = "unset";
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="intro-gate"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="intro-title"
+    >
+      <div className="intro-panel" ref={gateRef}>
+        <p className="intro-kicker">Scrollytelling Guide</p>
+        <h1 className="intro-title" id="intro-title">
+          Enter the Bloodborne Signal
+        </h1>
+        <p className="intro-body">
+          Move through the chapters to uncover the author, the stories, and the
+          world they inhabit.
+        </p>
+        <div className="intro-actions">
+          <button type="button" className="intro-primary" onClick={onEnter} ref={enterRef}>
+            Enter site
+          </button>
+          <button type="button" className="intro-secondary" onClick={onOpenNote}>
+            Read the note
+          </button>
+        </div>
+        <p className="intro-footnote">Tip: Use the chapter rail to jump ahead.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scrollytelling/NoteModal.jsx
+++ b/src/components/scrollytelling/NoteModal.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export default function NoteModal({ isOpen, onClose }) {
+  const modalRef = useRef(null);
+  const closeRef = useRef(null);
+  const previouslyFocused = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocused.current = document.activeElement;
+    if (closeRef.current) {
+      closeRef.current.focus();
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !modalRef.current) return;
+      const focusable = modalRef.current.querySelectorAll(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      if (previouslyFocused.current instanceof HTMLElement) {
+        previouslyFocused.current.focus();
+      }
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="note-overlay"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="note-modal"
+        ref={modalRef}
+        aria-labelledby="note-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="note-header">
+          <p className="note-kicker">Intro Note</p>
+          <button
+            type="button"
+            className="note-close"
+            onClick={onClose}
+            ref={closeRef}
+            aria-label="Close intro note"
+          >
+            ×
+          </button>
+        </div>
+        <h2 id="note-title">Welcome to the guide</h2>
+        <p className="note-body">
+          This experience is built for one continuous scroll with gentle motion.
+          If you prefer less animation, your settings will automatically reduce
+          movement without hiding any content.
+        </p>
+        <p className="note-body">
+          As you explore, keep an eye on the chapter rail for quick navigation.
+        </p>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/scrollytelling/ProgressIndicator.jsx
+++ b/src/components/scrollytelling/ProgressIndicator.jsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+export default function ProgressIndicator({ chapters = [] }) {
+  const [progress, setProgress] = useState(0);
+  const [activeId, setActiveId] = useState(chapters[0]?.id);
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const doc = document.documentElement;
+      const total = doc.scrollHeight - window.innerHeight;
+      const nextProgress = total > 0 ? (window.scrollY / total) * 100 : 0;
+      setProgress(Math.min(100, Math.max(0, nextProgress)));
+    };
+
+    updateProgress();
+    window.addEventListener("scroll", updateProgress, { passive: true });
+    window.addEventListener("resize", updateProgress);
+
+    return () => {
+      window.removeEventListener("scroll", updateProgress);
+      window.removeEventListener("resize", updateProgress);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chapters.length) return undefined;
+    if (typeof IntersectionObserver === "undefined") return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.4 }
+    );
+
+    chapters.forEach(({ id }) => {
+      const element = document.getElementById(id);
+      if (element) observer.observe(element);
+    });
+
+    return () => observer.disconnect();
+  }, [chapters]);
+
+  const scrollToChapter = useCallback((id) => {
+    const element = document.getElementById(id);
+    if (!element) return;
+    const offset = 96;
+    const top = element.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top, behavior: "smooth" });
+  }, []);
+
+  return (
+    <aside
+      className="progress-indicator"
+      aria-label="Scroll progress"
+      role="navigation"
+    >
+      <div className="progress-track" aria-hidden="true">
+        <span className="progress-bar" style={{ height: `${progress}%` }} />
+      </div>
+      <div className="progress-metric" aria-hidden="true">
+        {Math.round(progress)}%
+      </div>
+      <ol className="progress-chapters">
+        {chapters.map(({ id, number, label }) => {
+          const isActive = activeId === id;
+          return (
+            <li key={id}>
+              <button
+                type="button"
+                className={`progress-link${isActive ? " is-active" : ""}`}
+                onClick={() => scrollToChapter(id)}
+                aria-current={isActive ? "step" : undefined}
+                aria-label={`Jump to chapter ${number}: ${label}`}
+              >
+                <span className="progress-number">{number}</span>
+                <span className="progress-label">{label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </aside>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,46 @@
 /* index.css — Global Gothic Theme */
 
+@import "./styles/scrollytelling.css";
+
 :root {
-  /* pull in the same palette for global use */
+  /* Design tokens */
+  --color-base-950: #050607;
+  --color-base-900: #0d1014;
+  --color-base-800: #1d1f25;
+  --color-base-100: #f4f1ea;
+  --color-base-0: #ffffff;
+  --color-accent: #b9211d;
+  --color-accent-soft: rgba(185, 33, 29, 0.18);
+  --color-glow: rgba(185, 33, 29, 0.45);
+
+  --space-1: 0.5rem;
+  --space-2: 0.75rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+  --space-6: 3rem;
+  --space-7: 4.5rem;
+
+  --type-xs: 0.75rem;
+  --type-sm: 0.9rem;
+  --type-md: 1rem;
+  --type-lg: 1.25rem;
+  --type-xl: 1.6rem;
+  --type-2xl: 2.4rem;
+  --type-3xl: 3.2rem;
+
+  --font-display: "Cinzel Decorative", serif;
+  --font-body: "Inter", "Cinzel Decorative", serif;
+
+  /* Legacy palette compatibility */
   --color-black: #010800;
-  --color-burgundy: #1B0C00;
+  --color-burgundy: #1b0c00;
   --color-chocolate: #351304;
-  --color-russet: #8C5431;
-  --color-blood-red: #B9211D;
-  --color-antique-gold: #CDB48B;
+  --color-russet: #8c5431;
+  --color-blood-red: #b9211d;
+  --color-antique-gold: #cdb48b;
+  --blood-red: var(--color-accent);
+  --antique-gold: var(--color-base-100);
 }
 
 * {
@@ -18,21 +51,14 @@
 
 /* smooth full-page scroll on sections */
 html {
-  scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
-  background: var(--color-black);
-  color: var(--color-antique-gold);
-  font-family: "Cinzel Decorative", serif;
+  background: var(--color-base-950);
+  color: var(--color-base-100);
+  font-family: var(--font-body);
 }
 
 body {
-  /* subtle burgundy → black fade */
-  background: linear-gradient(
-    180deg,
-    var(--color-black) 0%,
-    var(--color-burgundy) 60%,
-    var(--color-black) 100%
-  );
+  background: radial-gradient(circle at top, rgba(12, 14, 20, 0.9), var(--color-base-950));
   min-height: 100vh;
   overflow-x: hidden;
 }
@@ -45,8 +71,8 @@ a {
 }
 a:hover,
 a:focus {
-  color: var(--color-blood-red);
-  text-shadow: 0 0 6px rgba(185,33,29,0.7);
+  color: var(--color-accent);
+  text-shadow: 0 0 12px var(--color-glow);
   filter: brightness(1.2);
 }
 
@@ -57,23 +83,17 @@ a:focus {
   margin: 0 auto;
 }
 
-/* each <section> fills viewport & snaps */
-section {
-  height: 100vh;
-  scroll-snap-align: center;
-}
-
 /* headings get a heavier gothic heft */
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Cinzel Decorative", serif;
-  color: var(--color-blood-red);
-  text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
+  font-family: var(--font-display);
+  color: var(--color-accent);
+  text-shadow: 2px 2px 6px rgba(0,0,0,0.75);
 }
 
 /* paragraphs and lists in softer antique gold */
 p, li {
-  color: var(--color-antique-gold);
-  line-height: 1.6;
+  color: var(--color-base-100);
+  line-height: 1.7;
 }
 
 /* responsive container widths */
@@ -109,7 +129,7 @@ p, li {
   width: auto;
   height: auto;
   padding: 0.5rem 1rem;
-  background: var(--color-blood-red);
+  background: var(--color-accent);
   color: #fff;
   z-index: 1000;
   text-decoration: none;
@@ -117,8 +137,8 @@ p, li {
 
 /* Global focus style */
 :focus-visible {
-  outline: 2px dashed var(--color-blood-red);
-  outline-offset: 2px;
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 3px;
 }
 
 /* Footer styles */
@@ -131,14 +151,12 @@ p, li {
 
 /* Light theme overrides */
 html.light {
-  --color-black: #ffffff;
-  --color-burgundy: #f3f3f3;
-  --color-chocolate: #333333;
-  --color-russet: #666666;
-  --color-blood-red: #8b0000;
-  --color-antique-gold: #333333;
-  background: var(--color-black);
-  color: var(--color-chocolate);
+  --color-base-950: #f6f6f6;
+  --color-base-900: #ffffff;
+  --color-base-100: #1d1f25;
+  --color-accent: #8b0000;
+  background: var(--color-base-900);
+  color: var(--color-base-100);
 }
 html.light body {
   background: #ffffff;

--- a/src/styles/scrollytelling.css
+++ b/src/styles/scrollytelling.css
@@ -1,0 +1,326 @@
+/* Scrollytelling shell */
+.scrolly-shell {
+  position: relative;
+  padding-bottom: var(--space-7);
+}
+
+.scrolly-track {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+}
+
+.scrolly-track[aria-hidden="true"] {
+  pointer-events: none;
+  filter: blur(2px);
+}
+
+.scrolly-chapter {
+  min-height: 100vh;
+  padding: clamp(3rem, 8vw, 6rem) clamp(1.5rem, 6vw, 6rem);
+  opacity: 0.15;
+  transform: translateY(40px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.scrolly-chapter.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.scrolly-chapter--right .chapter-grid {
+  grid-template-areas: "media meta";
+}
+
+.chapter-grid {
+  display: grid;
+  gap: var(--space-6);
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+}
+
+.chapter-meta {
+  grid-area: meta;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 520px;
+}
+
+.chapter-number {
+  font-size: var(--type-sm);
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-base-100);
+  opacity: 0.7;
+}
+
+.chapter-title {
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.1;
+}
+
+.chapter-statement {
+  font-size: var(--type-lg);
+  font-weight: 600;
+  color: var(--color-base-0);
+}
+
+.chapter-media {
+  grid-area: media;
+  position: relative;
+  min-height: 320px;
+  border-radius: 24px;
+  overflow: hidden;
+  background: rgba(13, 16, 20, 0.55);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.35);
+}
+
+.chapter-loading {
+  padding: var(--space-4);
+  color: var(--color-base-100);
+  font-size: var(--type-sm);
+}
+
+@media (min-width: 960px) {
+  .chapter-grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+    grid-template-areas: "meta media";
+  }
+
+  .scrolly-chapter--right .chapter-grid {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+
+  .chapter-meta {
+    position: sticky;
+    top: clamp(5rem, 15vh, 10rem);
+  }
+}
+
+/* Intro gate */
+.intro-gate {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 5, 7, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 60;
+  backdrop-filter: blur(10px);
+}
+
+.intro-panel {
+  max-width: 560px;
+  padding: var(--space-6);
+  border-radius: 24px;
+  background: rgba(15, 18, 24, 0.95);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  text-align: left;
+}
+
+.intro-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: var(--type-xs);
+  color: var(--color-base-100);
+  opacity: 0.7;
+}
+
+.intro-title {
+  margin: var(--space-2) 0;
+  font-size: clamp(2.2rem, 5vw, 3.5rem);
+}
+
+.intro-body {
+  font-size: var(--type-lg);
+}
+
+.intro-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.intro-primary,
+.intro-secondary {
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-size: var(--type-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.intro-primary {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: 0 12px 30px var(--color-glow);
+}
+
+.intro-secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--color-base-100);
+}
+
+.intro-footnote {
+  margin-top: var(--space-4);
+  font-size: var(--type-xs);
+  opacity: 0.7;
+}
+
+/* Note modal */
+.note-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 3, 5, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 70;
+  padding: var(--space-4);
+}
+
+.note-modal {
+  max-width: 520px;
+  background: var(--color-base-900);
+  padding: var(--space-5);
+  border-radius: 20px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+.note-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.note-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: var(--type-xs);
+  color: var(--color-base-100);
+  opacity: 0.7;
+}
+
+.note-close {
+  border: none;
+  background: transparent;
+  color: var(--color-base-100);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.note-body {
+  margin-top: var(--space-2);
+}
+
+/* Progress indicator */
+.progress-indicator {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2.5rem);
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-3);
+  z-index: 40;
+}
+
+.progress-track {
+  width: 4px;
+  height: 180px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  display: block;
+  width: 100%;
+  background: var(--color-accent);
+  box-shadow: 0 0 12px var(--color-glow);
+  transition: height 0.2s ease;
+}
+
+.progress-metric {
+  font-size: var(--type-xs);
+  letter-spacing: 0.1em;
+}
+
+.progress-chapters {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+}
+
+.progress-link {
+  display: grid;
+  gap: 0.15rem;
+  justify-items: end;
+  background: transparent;
+  border: none;
+  color: var(--color-base-100);
+  font-size: var(--type-xs);
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+.progress-link.is-active {
+  opacity: 1;
+  color: var(--color-base-0);
+}
+
+.progress-number {
+  font-size: var(--type-sm);
+  letter-spacing: 0.2em;
+}
+
+/* Immersive placeholder */
+.immersive-scene,
+.immersive-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  padding: var(--space-5);
+}
+
+.immersive-frame {
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  border-radius: 20px;
+  padding: var(--space-5);
+  text-align: center;
+  max-width: 480px;
+}
+
+.immersive-title {
+  font-size: var(--type-lg);
+  color: var(--color-base-0);
+  margin-bottom: var(--space-2);
+}
+
+.immersive-body {
+  font-size: var(--type-sm);
+  opacity: 0.8;
+}
+
+@media (max-width: 900px) {
+  .progress-indicator {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrolly-chapter {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Modernize the homepage UX into a single long-scroll, chaptered “scrollytelling” experience while preserving existing routes, data, and functionality. 
- Provide an accessible, performance-conscious shell that supports future immersive (WebGL/3D) content and respects `prefers-reduced-motion` and device capabilities.

### Description
- Add a scrollytelling scaffold and UI primitives: `Chapter`, `ProgressIndicator`, `IntroGate`, `NoteModal`, and `ImmersiveScene` under `src/components/scrollytelling/` to implement numbered chapters, an intro gate, an accessible intro note modal, and a progress rail. 
- Replace the homepage layout with a scrollytelling track in `src/App.jsx` wired to lazy-loaded pieces (keeps existing `Hero`, `BookPreview`, `About`, `Newsletter` intact) and added logic to conditionally enable the immersive layer based on `prefers-reduced-motion`, `navigator.deviceMemory`, `navigator.hardwareConcurrency`, and screen size. 
- Make `Hero`, `About`, and `BookPreview` accept wrapper props (`as`, optional `id`) so they can be embedded inside `Chapter` without reworking component internals. 
- Introduce design tokens and new scrollytelling styles: global tokens in `src/index.css` and component styles in `src/styles/scrollytelling.css` to establish spacing, type scale, colors, motion-friendly transitions, and a tight neutral + accent palette. 
- Add runtime guards and accessibility improvements: `IntersectionObserver`/`matchMedia` checks for SSR/testing safety, focus management and trap for `IntroGate` and `NoteModal`, ARIA labels, keyboard handlers, and `prefers-reduced-motion` fallbacks; leave a `TODO` in `ImmersiveScene` as a placeholder for a future WebGL/3D integration. 

### Testing
- Ran unit/integration tests with `npm test` (Vitest) which passed. 
- Ran a production build with `npm run build` (Vite) which completed successfully. 
- Ran linter via `npm run lint` earlier in the rollout which failed due to an external ESLint configuration parsing error related to a `languageOptions` globals whitespace issue (config problem, not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e910bcc08329a5d8c1c472553747)