### PR TITLE
Stabilize scrollytelling: scope CSS, fix ESLint, and gate /experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project powers the online presence of **Melissa Michaels**, author of *Rave
 ## Project Structure
 
 - `src/components` – React components for the hero, about section, services (book models, Patreon links), and newsletter form
+- `src/experience` – chapter-based scrollytelling experience with data, components, and hooks
 - `public` – static assets such as the *Raven's Revenge* cover, 3D model files and icons
 
 ## Getting Started
@@ -52,6 +53,7 @@ VITE_PUBLIC_KEY=your_public_key
 - Interactive 3D models for signed books, Patreon exclusives and newsletter perks
 - "About the Author" section describing Melissa and her writing journey
 - Newsletter sign‑up form powered by EmailJS
+- `/experience` route featuring a chaptered narrative with insight hotspots and a lightweight 3D backdrop
 - Video gallery showcasing book trailers and interviews
 
 The codebase is intentionally minimal to keep the focus on promoting **The Bloodborne Chronicles**. Feel free to adapt it for your own author site or book series.
@@ -87,3 +89,10 @@ the `/blog` page and can be viewed individually at `/blog/<slug>`.
 
 New posts are automatically included the next time the app runs.
 
+## Experience Page
+
+Visit `/experience` to view the scroll-driven narrative experience. Chapters and insight snippets live in:
+
+- `src/experience/data/chapters.js`
+
+Each chapter entry includes its number, title, body copy, visual state (lighting/camera hints), and insight snippet. Adjust this file to change the story flow or update the collectible insights.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,9 @@ export default [
     files: ["**/*.{js,jsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: Object.fromEntries(
+        Object.entries(globals.browser).map(([key, value]) => [key.trim(), value])
+      ),
       parserOptions: {
         ecmaVersion: "latest",
         ecmaFeatures: { jsx: true },
@@ -31,6 +33,8 @@ export default [
       "no-unused-vars": "warn",
       "react/prop-types": "off",
       "react/jsx-no-target-blank": "off",
+      "react/no-unescaped-entities": "off",
+      "react/no-unknown-property": "off",
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "gh-pages": "^6.3.0",
+        "globals": "^11.12.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.4",
         "vite": "^5.4.10",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "gh-pages": "^6.3.0",
+    "globals": "^11.12.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.4",
     "vite": "^5.4.10",

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,16 +1,19 @@
 import React from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 import Nav from './hero/Nav'
 import Footer from './footer/Footer'
 
 export default function Layout() {
+  const location = useLocation()
+  const hideChrome = location.pathname === '/experience'
+
   return (
     <div className="flex flex-col min-h-screen">
-      <Nav />
-      <div className="flex-1 pt-16">
+      {!hideChrome && <Nav />}
+      <div className={`flex-1${hideChrome ? '' : ' pt-16'}`}>
         <Outlet />
       </div>
-      <Footer />
+      {!hideChrome && <Footer />}
     </div>
   )
 }

--- a/src/components/hero/Nav.jsx
+++ b/src/components/hero/Nav.jsx
@@ -143,6 +143,7 @@ export default function Nav() {
 
   // Check if we're on blog pages
   const isBlogActive = location.pathname.startsWith("/blog");
+  const isExperienceActive = location.pathname === "/experience";
 
   return (
     <nav 
@@ -198,6 +199,26 @@ export default function Nav() {
           aria-current={isBlogActive ? "page" : undefined}
         >
           Blog
+        </li>
+
+        <li
+          onClick={() => {
+            navigate("/experience");
+            closeMenu();
+          }}
+          role="menuitem"
+          tabIndex={open ? 0 : -1}
+          onKeyDown={(e) =>
+            handleKeyDown(e, () => {
+              navigate("/experience");
+              closeMenu();
+            })
+          }
+          aria-label="Navigate to Experience page"
+          className={isExperienceActive ? "nav__link--active" : ""}
+          aria-current={isExperienceActive ? "page" : undefined}
+        >
+          Experience
         </li>
       </ul>
 

--- a/src/experience/ExperiencePage.jsx
+++ b/src/experience/ExperiencePage.jsx
@@ -1,0 +1,109 @@
+import React, { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { useReducedMotion } from "motion/react";
+import SEO from "../components/utility/SEO";
+import chapters from "./data/chapters";
+import ExperienceGate from "./components/ExperienceGate";
+import ExperienceOverlay from "./components/ExperienceOverlay";
+import ExperienceChapter from "./components/ExperienceChapter";
+import ExperienceModal from "./components/ExperienceModal";
+import useActiveChapter from "./hooks/useActiveChapter";
+import useInsights from "./hooks/useInsights";
+import "./experience.css";
+
+const ExperienceScene = lazy(() => import("./components/ExperienceScene"));
+
+export default function ExperiencePage() {
+  const prefersReducedMotion = useReducedMotion();
+  const [authorNoteOpen, setAuthorNoteOpen] = useState(false);
+  const [activeInsight, setActiveInsight] = useState(null);
+  const [hasEntered, setHasEntered] = useState(false);
+
+  const chapterIds = useMemo(() => chapters.map((chapter) => chapter.id), []);
+  const activeChapterId = useActiveChapter(chapterIds);
+  const activeChapter = chapters.find((chapter) => chapter.id === activeChapterId) ?? chapters[0];
+
+  const { foundSet, foundCount, markFound } = useInsights();
+
+  useEffect(() => {
+    document.documentElement.classList.add("experience-active");
+    return () => document.documentElement.classList.remove("experience-active");
+  }, []);
+
+  const handleNavigate = (id) => {
+    const element = document.getElementById(id);
+    if (!element) return;
+    const offset = 90;
+    const top = element.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top, behavior: prefersReducedMotion ? "auto" : "smooth" });
+  };
+
+  const handleOpenInsight = (chapter) => {
+    setActiveInsight(chapter);
+    markFound(chapter.insight.id);
+  };
+
+  return (
+    <main className="experience-page scrolly-shell">
+      <SEO title="Experience | Melissa Michaels" description="Interactive author experience" />
+      <ExperienceGate isOpen={!hasEntered} onEnter={() => setHasEntered(true)} />
+
+      {hasEntered && (
+        <>
+          <Suspense fallback={<div className="experience-scene__fallback" aria-hidden="true" />}>
+            <ExperienceScene
+              visualState={activeChapter.visualState}
+              reducedMotion={prefersReducedMotion}
+            />
+          </Suspense>
+
+          <ExperienceOverlay
+            chapters={chapters}
+            activeId={activeChapterId}
+            onNavigate={handleNavigate}
+            onOpenNote={() => setAuthorNoteOpen(true)}
+            insightsFound={foundCount}
+            insightsTotal={chapters.length}
+          />
+
+          <div className="experience-track scrolly-track">
+            {chapters.map((chapter) => (
+              <ExperienceChapter
+                key={chapter.id}
+                chapter={chapter}
+                isFound={foundSet.has(chapter.insight.id)}
+                onOpenInsight={handleOpenInsight}
+                reducedMotion={prefersReducedMotion}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <ExperienceModal
+        isOpen={authorNoteOpen}
+        title="Author’s Note"
+        onClose={() => setAuthorNoteOpen(false)}
+        labelledBy="author-note-title"
+      >
+        <p>
+          The /experience page is designed as a living guide to the Bloodborne Chronicles—part
+          transmission log, part reader dossier. Each chapter offers a short insight to deepen the
+          journey without changing the story’s canon.
+        </p>
+        <p>
+          Prefer a quieter ride? Your reduced-motion setting will keep everything readable while
+          dialing down animation.
+        </p>
+      </ExperienceModal>
+
+      <ExperienceModal
+        isOpen={Boolean(activeInsight)}
+        title={activeInsight?.title ?? "Insight"}
+        onClose={() => setActiveInsight(null)}
+        labelledBy="insight-title"
+      >
+        <p>{activeInsight?.insight.snippet}</p>
+      </ExperienceModal>
+    </main>
+  );
+}

--- a/src/experience/ExperiencePage.test.jsx
+++ b/src/experience/ExperiencePage.test.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("./components/ExperienceScene", () => ({
+  default: () => <div data-testid="experience-scene" />,
+}));
+
+import ExperiencePage from "./ExperiencePage.jsx";
+
+describe("ExperiencePage", () => {
+  it("renders overlay navigation with six chapters", async () => {
+    render(<ExperiencePage />);
+    fireEvent.click(screen.getByRole("button", { name: /enter experience/i }));
+    await screen.findByTestId("experience-scene");
+    const buttons = screen.getAllByRole("button", { name: /Jump to chapter/i });
+    expect(buttons).toHaveLength(6);
+  });
+});

--- a/src/experience/components/ExperienceChapter.jsx
+++ b/src/experience/components/ExperienceChapter.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef, useState } from "react";
+import InsightHotspot from "./InsightHotspot";
+
+export default function ExperienceChapter({
+  chapter,
+  isFound,
+  onOpenInsight,
+  reducedMotion,
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const sectionRef = useRef(null);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setIsVisible(true);
+      return;
+    }
+    if (typeof IntersectionObserver === "undefined") {
+      setIsVisible(true);
+      return;
+    }
+
+    const element = sectionRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        }
+      },
+      { threshold: 0.3 }
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [reducedMotion]);
+
+  return (
+    <section
+      id={chapter.id}
+      ref={sectionRef}
+      className={`experience-chapter scrolly-chapter${isVisible ? " is-visible" : ""}`}
+      aria-labelledby={`${chapter.id}-title`}
+      data-visual={chapter.id}
+    >
+      <div className="experience-chapter__content">
+        <p className="experience-chapter__number">{chapter.number}</p>
+        <h2 id={`${chapter.id}-title`}>{chapter.title}</h2>
+        <p className="experience-chapter__body">{chapter.body}</p>
+        <InsightHotspot
+          label={chapter.insight.label}
+          isFound={isFound}
+          onOpen={() => onOpenInsight(chapter)}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/experience/components/ExperienceGate.jsx
+++ b/src/experience/components/ExperienceGate.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from "react";
+
+export default function ExperienceGate({ isOpen, onEnter }) {
+  const buttonRef = useRef(null);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    buttonRef.current?.focus();
+
+    const handleKeyDown = (event) => {
+      if (event.key !== "Tab" || !panelRef.current) return;
+      const focusable = panelRef.current.querySelectorAll(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="experience-gate" role="dialog" aria-modal="true" aria-labelledby="experience-gate-title">
+      <div className="experience-gate__panel" ref={panelRef}>
+        <p className="experience-gate__kicker">Interactive Guide</p>
+        <h1 id="experience-gate-title">Enter the Bloodborne Signal</h1>
+        <p>
+          Move through six chapters to uncover the author’s world, unlock insights, and track your progress.
+        </p>
+        <button
+          type="button"
+          className="experience-gate__enter"
+          onClick={onEnter}
+          ref={buttonRef}
+        >
+          Enter experience
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/experience/components/ExperienceModal.jsx
+++ b/src/experience/components/ExperienceModal.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from "react";
+
+export default function ExperienceModal({ isOpen, title, children, onClose, labelledBy }) {
+  const modalRef = useRef(null);
+  const closeRef = useRef(null);
+  const previousFocus = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    previousFocus.current = document.activeElement;
+    closeRef.current?.focus();
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !modalRef.current) return;
+      const focusable = modalRef.current.querySelectorAll(
+        'button, [href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      if (previousFocus.current instanceof HTMLElement) {
+        previousFocus.current.focus();
+      }
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="experience-modal__overlay" role="dialog" aria-modal="true" onClick={onClose}>
+      <div
+        className="experience-modal"
+        ref={modalRef}
+        aria-labelledby={labelledBy}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="experience-modal__header">
+          <div>
+            <p className="experience-modal__kicker">Author Insights</p>
+            <h2 id={labelledBy}>{title}</h2>
+          </div>
+          <button
+            type="button"
+            className="experience-modal__close"
+            onClick={onClose}
+            aria-label="Close modal"
+            ref={closeRef}
+          >
+            ×
+          </button>
+        </header>
+        <div className="experience-modal__body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/experience/components/ExperienceOverlay.jsx
+++ b/src/experience/components/ExperienceOverlay.jsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from "react";
+
+export default function ExperienceOverlay({
+  chapters,
+  activeId,
+  onNavigate,
+  onOpenNote,
+  insightsFound,
+  insightsTotal,
+}) {
+  const activeIndex = useMemo(
+    () => chapters.findIndex((chapter) => chapter.id === activeId),
+    [chapters, activeId]
+  );
+
+  const activeNumber = activeIndex >= 0 ? chapters[activeIndex].number : "01";
+
+  return (
+    <aside className="experience-overlay" aria-label="Experience controls">
+      <div className="experience-overlay__top">
+        <div>
+          <p className="experience-overlay__label">Active chapter</p>
+          <div className="experience-overlay__chapter">
+            <span>{activeNumber}</span>
+            <span className="experience-overlay__divider">/</span>
+            <span>{chapters.length.toString().padStart(2, "0")}</span>
+          </div>
+        </div>
+        <button type="button" className="experience-overlay__note" onClick={onOpenNote}>
+          Author’s Note
+        </button>
+      </div>
+
+      <nav aria-label="Chapter navigation">
+        <ol className="experience-overlay__nav">
+          {chapters.map((chapter, index) => {
+            const isActive = chapter.id === activeId;
+            return (
+              <li key={chapter.id}>
+                <button
+                  type="button"
+                  className={`experience-overlay__nav-button${isActive ? " is-active" : ""}`}
+                  onClick={() => onNavigate(chapter.id)}
+                  aria-current={isActive ? "step" : undefined}
+                  aria-label={`Jump to chapter ${index + 1}: ${chapter.title}`}
+                >
+                  {chapter.number}
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <div className="experience-overlay__insights" aria-live="polite">
+        <span>Insights found</span>
+        <strong>
+          {insightsFound}/{insightsTotal}
+        </strong>
+      </div>
+    </aside>
+  );
+}

--- a/src/experience/components/ExperienceScene.jsx
+++ b/src/experience/components/ExperienceScene.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+function Sigil({ color, reducedMotion }) {
+  const meshRef = useRef(null);
+
+  useFrame((state) => {
+    if (reducedMotion || !meshRef.current) return;
+    meshRef.current.rotation.z = state.clock.elapsedTime * 0.1;
+    meshRef.current.rotation.x = state.clock.elapsedTime * 0.05;
+  });
+
+  return (
+    <mesh ref={meshRef} position={[0, 0, 0]}>
+      <torusKnotGeometry args={[1.2, 0.35, 120, 12]} />
+      <meshStandardMaterial color={color} metalness={0.6} roughness={0.3} />
+    </mesh>
+  );
+}
+
+function SceneRig({ visualState }) {
+  const { camera, scene } = useThree();
+
+  useEffect(() => {
+    if (!visualState) return;
+    camera.position.set(...visualState.camera);
+    camera.lookAt(0, 0, 0);
+    if (visualState.fog) {
+      const [color, near, far] = visualState.fog;
+      scene.fog = new THREE.Fog(color, near, far);
+    }
+  }, [camera, scene, visualState]);
+
+  return null;
+}
+
+export default function ExperienceScene({ visualState, reducedMotion }) {
+  const accent = visualState?.accent ?? "#b9211d";
+  const ambientIntensity = visualState?.ambient ?? 0.4;
+  const spotIntensity = visualState?.spot ?? 0.8;
+
+  const background = useMemo(() => ({
+    color: visualState?.fog?.[0] ?? "#050607",
+  }), [visualState]);
+
+  return (
+    <div className="experience-scene" aria-hidden="true">
+      <Canvas
+        dpr={[1, 1.5]}
+        camera={{ position: visualState?.camera ?? [0, 2, 6], fov: 50 }}
+      >
+        <color attach="background" args={[background.color]} />
+        <ambientLight intensity={ambientIntensity} />
+        <directionalLight position={[4, 6, 5]} intensity={spotIntensity} color={accent} />
+        <SceneRig visualState={visualState} />
+        <Sigil color={accent} reducedMotion={reducedMotion} />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/experience/components/InsightHotspot.jsx
+++ b/src/experience/components/InsightHotspot.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function InsightHotspot({ label, isFound, onOpen }) {
+  return (
+    <button
+      type="button"
+      className={`experience-hotspot${isFound ? " is-found" : ""}`}
+      onClick={onOpen}
+      aria-pressed={isFound}
+      aria-label={`${label} insight`}
+    >
+      <span className="experience-hotspot__dot" aria-hidden="true" />
+      <span className="experience-hotspot__label">{label}</span>
+    </button>
+  );
+}

--- a/src/experience/data/chapters.js
+++ b/src/experience/data/chapters.js
@@ -1,0 +1,124 @@
+const chapters = [
+  {
+    id: "signal",
+    number: "01",
+    title: "Signal in the static",
+    body:
+      "Follow the flicker between surveillance feeds and the bloodlines that refuse to stay hidden.",
+    visualState: {
+      accent: "#b9211d",
+      ambient: 0.4,
+      spot: 0.9,
+      camera: [0, 1.8, 6],
+      fog: ["#050607", 4, 12],
+    },
+    insight: {
+      id: "signal",
+      label: "Find the signal",
+      snippet:
+        "Every transmission carries a ghost. The Bloodborne Chronicles begin where the feeds go quiet.",
+    },
+  },
+  {
+    id: "raven",
+    number: "02",
+    title: "Raven’s first breach",
+    body:
+      "Raven Andros maps extraction points while something older maps her back.",
+    visualState: {
+      accent: "#d15a3c",
+      ambient: 0.35,
+      spot: 0.8,
+      camera: [-1.2, 1.6, 6.5],
+      fog: ["#0b0d12", 4, 13],
+    },
+    insight: {
+      id: "raven",
+      label: "Trace Raven’s path",
+      snippet:
+        "Heat signatures lie. Raven trusts geometry until geometry stops trusting her.",
+    },
+  },
+  {
+    id: "bloodline",
+    number: "03",
+    title: "Bloodline protocols",
+    body:
+      "Family histories are rewritten with every mission, and every mission asks for more.",
+    visualState: {
+      accent: "#a45cff",
+      ambient: 0.45,
+      spot: 0.75,
+      camera: [1.4, 2.1, 6.2],
+      fog: ["#0c0f1a", 4, 14],
+    },
+    insight: {
+      id: "bloodline",
+      label: "Decode the bloodline",
+      snippet:
+        "The Andros line carries a signal that can’t be scrubbed from any report.",
+    },
+  },
+  {
+    id: "archives",
+    number: "04",
+    title: "Shadowed archives",
+    body:
+      "Every classified file hides the same question: who survives the next frame?",
+    visualState: {
+      accent: "#5bd0ff",
+      ambient: 0.35,
+      spot: 0.7,
+      camera: [0.4, 1.5, 5.8],
+      fog: ["#081016", 3, 11],
+    },
+    insight: {
+      id: "archives",
+      label: "Unseal the archive",
+      snippet:
+        "The oldest records are never fully redacted—they hum in the margins.",
+    },
+  },
+  {
+    id: "crossing",
+    number: "05",
+    title: "Crossing the threshold",
+    body:
+      "The feed fractures. The mission shifts from extraction to survival.",
+    visualState: {
+      accent: "#f0b94f",
+      ambient: 0.5,
+      spot: 0.85,
+      camera: [-0.6, 2.2, 6.8],
+      fog: ["#15110d", 4, 12],
+    },
+    insight: {
+      id: "crossing",
+      label: "Cross the line",
+      snippet:
+        "Once the threshold is crossed, the only command left is to keep moving.",
+    },
+  },
+  {
+    id: "signal-end",
+    number: "06",
+    title: "Signal end / signal begin",
+    body:
+      "The story loops back with new coordinates—an invitation to keep listening.",
+    visualState: {
+      accent: "#9ad16b",
+      ambient: 0.4,
+      spot: 0.8,
+      camera: [0, 1.9, 6.1],
+      fog: ["#0a120b", 4, 12],
+    },
+    insight: {
+      id: "signal-end",
+      label: "Log the aftermath",
+      snippet:
+        "The final frame is always the start of the next signal.",
+    },
+  },
+];
+
+export default chapters;

--- a/src/experience/experience.css
+++ b/src/experience/experience.css
@@ -1,0 +1,303 @@
+/* Experience page */
+.experience-page {
+  position: relative;
+  color: var(--color-antique-gold);
+  padding: 0 0 6rem;
+  min-height: 100vh;
+}
+
+html.experience-active {
+  height: 100%;
+}
+
+html.experience-active body {
+  height: 100%;
+  overflow: hidden;
+}
+
+.scrolly-shell {
+  height: 100vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scroll-padding-top: 2rem;
+}
+
+.experience-track {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 8vw, 6rem);
+  padding: clamp(6rem, 12vw, 9rem) clamp(1.5rem, 5vw, 5rem);
+}
+
+.scrolly-chapter {
+  min-height: 100vh;
+  scroll-snap-align: start;
+}
+
+.experience-chapter {
+  max-width: 720px;
+  opacity: 0.15;
+  transform: translateY(36px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.experience-chapter.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.experience-chapter__content {
+  display: grid;
+  gap: 1rem;
+  background: rgba(2, 4, 8, 0.6);
+  border-radius: 20px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.experience-chapter__number {
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--color-antique-gold);
+  opacity: 0.7;
+}
+
+.experience-chapter__body {
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.experience-hotspot {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(205, 180, 139, 0.4);
+  background: rgba(4, 8, 16, 0.8);
+  color: var(--color-antique-gold);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.experience-hotspot.is-found {
+  border-color: var(--color-blood-red);
+  color: #fff;
+  background: rgba(185, 33, 29, 0.2);
+}
+
+.experience-hotspot__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 10px rgba(185, 33, 29, 0.5);
+}
+
+.experience-scene {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.experience-scene__fallback {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(9, 12, 18, 0.7), rgba(1, 2, 4, 0.9));
+}
+
+.experience-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(2, 3, 6, 0.85);
+  backdrop-filter: blur(8px);
+  padding: 1.5rem;
+}
+
+.experience-gate__panel {
+  max-width: 520px;
+  background: rgba(10, 12, 18, 0.95);
+  border-radius: 18px;
+  padding: 2rem;
+  border: 1px solid rgba(205, 180, 139, 0.2);
+  display: grid;
+  gap: 1rem;
+  text-align: left;
+}
+
+.experience-gate__kicker {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  opacity: 0.7;
+}
+
+.experience-gate__enter {
+  border-radius: 999px;
+  border: 1px solid rgba(185, 33, 29, 0.6);
+  background: rgba(185, 33, 29, 0.3);
+  color: #fff;
+  padding: 0.6rem 1.4rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.experience-overlay {
+  position: fixed;
+  top: 6rem;
+  right: clamp(1rem, 4vw, 3rem);
+  z-index: 3;
+  display: grid;
+  gap: 1.5rem;
+  min-width: 160px;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(8, 12, 18, 0.85);
+  border: 1px solid rgba(205, 180, 139, 0.2);
+  backdrop-filter: blur(8px);
+}
+
+.experience-overlay__top {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.experience-overlay__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  opacity: 0.7;
+}
+
+.experience-overlay__chapter {
+  font-size: 1.4rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.experience-overlay__divider {
+  opacity: 0.6;
+}
+
+.experience-overlay__note {
+  border-radius: 999px;
+  border: 1px solid rgba(185, 33, 29, 0.6);
+  background: rgba(185, 33, 29, 0.2);
+  color: #fff;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.experience-overlay__nav {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.experience-overlay__nav-button {
+  border: 1px solid rgba(205, 180, 139, 0.4);
+  background: transparent;
+  color: var(--color-antique-gold);
+  padding: 0.3rem 0;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.experience-overlay__nav-button.is-active {
+  border-color: var(--color-blood-red);
+  color: #fff;
+  background: rgba(185, 33, 29, 0.3);
+}
+
+.experience-overlay__insights {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.experience-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+  padding: 1.5rem;
+}
+
+.experience-modal {
+  max-width: 520px;
+  width: 100%;
+  background: rgba(10, 12, 18, 0.95);
+  border-radius: 18px;
+  padding: 1.5rem;
+  color: #fff;
+  border: 1px solid rgba(205, 180, 139, 0.2);
+}
+
+.experience-modal__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.experience-modal__kicker {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  opacity: 0.7;
+}
+
+.experience-modal__close {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.experience-modal__body {
+  display: grid;
+  gap: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+  .experience-overlay {
+    position: sticky;
+    top: 5rem;
+    margin: 0 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrolly-shell {
+    scroll-behavior: auto;
+  }
+
+  .experience-chapter {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/experience/hooks/useActiveChapter.js
+++ b/src/experience/hooks/useActiveChapter.js
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react";
+
+export default function useActiveChapter(chapterIds = []) {
+  const [activeId, setActiveId] = useState(chapterIds[0]);
+
+  const ids = useMemo(() => chapterIds.filter(Boolean), [chapterIds]);
+
+  useEffect(() => {
+    if (!ids.length) return undefined;
+    if (typeof IntersectionObserver === "undefined") {
+      setActiveId(ids[0]);
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.4 }
+    );
+
+    ids.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) observer.observe(element);
+    });
+
+    return () => observer.disconnect();
+  }, [ids]);
+
+  return activeId;
+}

--- a/src/experience/hooks/useInsights.js
+++ b/src/experience/hooks/useInsights.js
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "experienceInsightsFound";
+
+export default function useInsights() {
+  const [foundIds, setFoundIds] = useState([]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setFoundIds(parsed);
+        }
+      }
+    } catch (error) {
+      console.warn("Unable to read insights from storage", error);
+    }
+  }, []);
+
+  const markFound = useCallback((id) => {
+    setFoundIds((prev) => {
+      if (prev.includes(id)) return prev;
+      const next = [...prev, id];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch (error) {
+        console.warn("Unable to save insights to storage", error);
+      }
+      return next;
+    });
+  }, []);
+
+  const foundSet = useMemo(() => new Set(foundIds), [foundIds]);
+
+  return {
+    foundIds,
+    foundSet,
+    foundCount: foundIds.length,
+    markFound,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,9 +16,7 @@
   box-sizing: border-box;
 }
 
-/* smooth full-page scroll on sections */
 html {
-  scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
   background: var(--color-black);
   color: var(--color-antique-gold);
@@ -55,12 +53,6 @@ a:focus {
   max-width: 1536px;
   padding: 0 1rem;
   margin: 0 auto;
-}
-
-/* each <section> fills viewport & snaps */
-section {
-  height: 100vh;
-  scroll-snap-align: center;
 }
 
 /* headings get a heavier gothic heft */

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,6 +10,7 @@ import Layout from './components/Layout.jsx'
 const BlogPage = lazy(() => import ('./components/blog/BlogPage'))
 const BlogPostWrapper = lazy(() => import('./components/blog/BlogPostWrapper'))
 const Post = lazy(() => import('./pages/Post.jsx'))
+const ExperiencePage = lazy(() => import('./experience/ExperiencePage.jsx'))
 
 createRoot(document.getElementById('root')).render(
 <StrictMode>
@@ -23,9 +24,10 @@ createRoot(document.getElementById('root')).render(
         <Routes>
           <Route element={<Layout />}>
             <Route index element={<App />} />
-            <Route path="blog" element={<BlogPage />} />
-            <Route path="blog/:slug" element={<BlogPostWrapper />} />
-            <Route path="post/:id" element={<Post />} />
+          <Route path="blog" element={<BlogPage />} />
+          <Route path="blog/:slug" element={<BlogPostWrapper />} />
+          <Route path="post/:id" element={<Post />} />
+          <Route path="experience" element={<ExperiencePage />} />
           </Route>
         </Routes>
       </Suspense>


### PR DESCRIPTION
### Motivation
- Prevent global CSS scroll-snap/section sizing from leaking into other pages and stop the immersive scrollytelling layout from being affected by the global Nav/Footer.
- Fix an ESLint crash caused by malformed globals and suppress a handful of JSX rules that conflict with React Three Fiber usage.
- Improve UX by gating the scrolly content until the user explicitly enters and respecting `prefers-reduced-motion` for scroll behavior.

### Description
- Add `globals` as a dev dependency and sanitize `globals.browser` keys in `eslint.config.js` via `Object.fromEntries(...map(([k,v]) => [k.trim(), v]))`, and relax `react/no-unescaped-entities` and `react/no-unknown-property` rules to avoid R3F false-positives.
- Remove global `scroll-snap` and full-viewport `section` rules from `src/index.css` and introduce scoped scrollytelling styles in `src/experience/experience.css` using `.scrolly-shell` and `.scrolly-chapter` so only the experience page uses snap/100vh behavior.
- Gate rendering of the heavy scrolly track and scene behind an `ExperienceGate` so the track is only mounted after the user clicks Enter, and ensure scroll navigation uses `behavior: "auto"` when reduced motion is preferred.
- Hide global `Nav` and `Footer` on the `/experience` route by checking `location.pathname` in `src/components/Layout.jsx` and add a route for the lazy-loaded `ExperiencePage` in `src/main.jsx`.
- Implement small UX/overlay tweaks: `ExperienceOverlay` shows the active chapter as `activeNumber / totalChapters`, `useActiveChapter` and `useInsights` hooks included, and the test `src/experience/ExperiencePage.test.jsx` updated to click Enter before asserting scene rendering.

### Testing
- Ran `npm run lint` and ESLint completed with no errors (only warnings remain) so the previous crash is resolved.
- Ran `npm test` and all tests passed (`src/App.test.jsx` and `src/experience/ExperiencePage.test.jsx`).
- Built a production bundle with `npm run build` which completed successfully (build emits chunk-size warnings as before).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e910bcc08329a5d8c1c472553747)