### PR TITLE
Gothic blog theme: add styles and replace BlogPost with themed implementation

### DIFF
--- a/src/components/blog/BlogPage.jsx
+++ b/src/components/blog/BlogPage.jsx
@@ -1,16 +1,15 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import PostPreview from './PostPreview';
 import SearchBar from '../utility/SearchBar';
 import Pagination from '../utility/Pagination';
-import posts from "../../data/posts.js";
-import shortStories from "../../data/shortStories.js";
+import posts from '../../data/posts.js';
+import shortStories from '../../data/shortStories.js';
 import { debounce } from 'lodash';
+import './blog.css';
 
 export default function AuthorBlogPage() {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [localPosts, setLocalPosts] = useState([]);
   const [showForm, setShowForm] = useState(false);
@@ -23,63 +22,82 @@ export default function AuthorBlogPage() {
   });
   const perPage = 6;
 
-  useEffect(() => {
-    const stored = window.localStorage.getItem('authorBlogPosts');
-    if (stored) {
-      try {
-        setLocalPosts(JSON.parse(stored));
-      } catch (err) {
-        console.error('Failed to parse local blog posts', err);
-      }
-    }
-  }, []);
+  const localDraftsEnabled = import.meta.env.DEV && import.meta.env.VITE_ENABLE_LOCAL_DRAFTS === 'true';
 
-  // Debounce search input to prevent excessive filtering
+  useEffect(() => {
+    if (!localDraftsEnabled) {
+      return;
+    }
+
+    const stored = window.localStorage.getItem('authorBlogPosts');
+    if (!stored) {
+      return;
+    }
+
+    try {
+      setLocalPosts(JSON.parse(stored));
+    } catch (err) {
+      console.error('Failed to parse local blog posts', err);
+      setError('Unable to load local drafts.');
+    }
+  }, [localDraftsEnabled]);
+
   const debouncedSetSearch = useMemo(
-    () => debounce((value) => {
-      setSearch(value);
-      setPage(1); // Reset to first page on new search
-    }, 300),
+    () =>
+      debounce((value) => {
+        setSearch(value);
+        setPage(1);
+      }, 300),
     []
   );
 
-  // Clean up debounce on component unmount
   useEffect(() => {
     return () => {
       debouncedSetSearch.cancel();
     };
   }, [debouncedSetSearch]);
 
-  const allPosts = useMemo(
-    () => [...localPosts, ...posts],
-    [localPosts]
-  );
+  const allPosts = useMemo(() => (localDraftsEnabled ? [...localPosts, ...posts] : posts), [localDraftsEnabled, localPosts]);
 
   const filtered = useMemo(() => {
-    setIsLoading(true);
-    try {
-      const result = allPosts.filter((post) =>
-        post.title?.toLowerCase().includes(search.toLowerCase()) ||
-        post.summary?.toLowerCase().includes(search.toLowerCase()) ||
-        (post.tags || []).some(tag =>
-          tag.toLowerCase().includes(search.toLowerCase())
-        )
-      );
-      setIsLoading(false);
-      return result;
-    } catch (err) {
-      setError('An error occurred while filtering posts.');
-      setIsLoading(false);
-      return [];
+    const term = search.trim().toLowerCase();
+    if (!term) {
+      return allPosts;
     }
+
+    return allPosts.filter(
+      (post) =>
+        post.title?.toLowerCase().includes(term) ||
+        post.summary?.toLowerCase().includes(term) ||
+        (post.tags || []).some((tag) => tag.toLowerCase().includes(term))
+    );
   }, [allPosts, search]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / perPage));
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
 
   const paginated = useMemo(() => {
     const start = (page - 1) * perPage;
     return filtered.slice(start, start + perPage);
   }, [filtered, page]);
 
-  const totalPages = Math.ceil(filtered.length / perPage);
+  const publishedShortStories = useMemo(
+    () =>
+      shortStories.filter((story) => {
+        try {
+          const parsed = new URL(story.url);
+          return parsed.hostname !== 'example.com';
+        } catch {
+          return false;
+        }
+      }),
+    []
+  );
 
   const handleFormChange = (event) => {
     const { name, value } = event.target;
@@ -96,10 +114,7 @@ export default function AuthorBlogPage() {
       return;
     }
 
-    const slugBase = trimmedTitle
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '');
+    const slugBase = trimmedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 
     const newPost = {
       slug: `${slugBase}-${Date.now()}`,
@@ -126,163 +141,123 @@ export default function AuthorBlogPage() {
   };
 
   return (
-    <section className="max-w-5xl mx-auto px-4 py-10" aria-labelledby="blog-title">
-      <h1 id="blog-title" className="text-4xl font-bold mb-6 text-gray-900">
+    <section className="blog-shell max-w-5xl mx-auto px-4 py-10" aria-labelledby="blog-title">
+      <h1 id="blog-title" className="text-4xl font-bold mb-6 blog-heading">
         Author’s Blog
       </h1>
-      <div className="bg-stone-950/90 border border-amber-200/20 text-amber-100 rounded-2xl p-6 mb-10 shadow-lg">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-lg font-semibold">Publish a new entry</p>
-            <p className="text-sm text-amber-200/80">
-              Draft posts here to keep your blog fresh. Posts save to this device and appear immediately.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => setShowForm((prev) => !prev)}
-            className="px-4 py-2 rounded-lg bg-amber-200 text-stone-900 font-semibold hover:bg-amber-300 transition-colors"
-          >
-            {showForm ? 'Hide form' : 'Write a post'}
-          </button>
-        </div>
-        {showForm && (
-          <form onSubmit={handleSubmit} className="mt-6 grid gap-4">
-            <label className="grid gap-2 text-sm">
-              Title
-              <input
-                name="title"
-                value={formState.title}
-                onChange={handleFormChange}
-                className="rounded-lg border border-amber-200/30 bg-stone-900/80 px-3 py-2 text-amber-100"
-                required
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              Summary
-              <input
-                name="summary"
-                value={formState.summary}
-                onChange={handleFormChange}
-                className="rounded-lg border border-amber-200/30 bg-stone-900/80 px-3 py-2 text-amber-100"
-                placeholder="Short teaser for the post."
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              Body (Markdown supported)
-              <textarea
-                name="body"
-                value={formState.body}
-                onChange={handleFormChange}
-                className="min-h-[140px] rounded-lg border border-amber-200/30 bg-stone-900/80 px-3 py-2 text-amber-100"
-                required
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              Tags (comma separated)
-              <input
-                name="tags"
-                value={formState.tags}
-                onChange={handleFormChange}
-                className="rounded-lg border border-amber-200/30 bg-stone-900/80 px-3 py-2 text-amber-100"
-                placeholder="fantasy, writing, events"
-              />
-            </label>
-            <label className="grid gap-2 text-sm">
-              Featured image URL
-              <input
-                name="featuredImage"
-                value={formState.featuredImage}
-                onChange={handleFormChange}
-                className="rounded-lg border border-amber-200/30 bg-stone-900/80 px-3 py-2 text-amber-100"
-                placeholder="https://..."
-              />
-            </label>
+
+      {localDraftsEnabled && (
+        <div className="blog-surface p-6 mb-10">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-lg font-semibold blog-heading">Publish a new entry</p>
+              <p className="text-sm blog-muted">Draft posts here for local preview. Entries are stored on this device only.</p>
+            </div>
             <button
-              type="submit"
-              className="w-full md:w-auto px-5 py-2 rounded-lg bg-red-700 text-white font-semibold hover:bg-red-800 transition-colors"
+              type="button"
+              onClick={() => setShowForm((prev) => !prev)}
+              className="px-4 py-2 font-semibold blog-button"
             >
-              Publish post
+              {showForm ? 'Hide form' : 'Write a post'}
             </button>
-          </form>
-        )}
-      </div>
-      <div className="mb-10">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-4">Short Stories</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          {shortStories.map((story) => (
-            <a
-              key={story.title}
-              href={story.url}
-              className="group block rounded-2xl border border-gray-200 bg-white p-5 shadow-md transition hover:-translate-y-1 hover:shadow-lg"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <p className="text-sm text-gray-500">{story.type}</p>
-              <p className="text-lg font-semibold text-gray-900 group-hover:text-red-700">{story.title}</p>
-              <p className="text-sm text-gray-600 mt-2">{story.description}</p>
-            </a>
-          ))}
+          </div>
+          {showForm && (
+            <form onSubmit={handleSubmit} className="mt-6 grid gap-4">
+              <label className="grid gap-2 text-sm">
+                Title
+                <input name="title" value={formState.title} onChange={handleFormChange} className="blog-input" required />
+              </label>
+              <label className="grid gap-2 text-sm">
+                Summary
+                <input
+                  name="summary"
+                  value={formState.summary}
+                  onChange={handleFormChange}
+                  className="blog-input"
+                  placeholder="Short teaser for the post."
+                />
+              </label>
+              <label className="grid gap-2 text-sm">
+                Body (Markdown supported)
+                <textarea name="body" value={formState.body} onChange={handleFormChange} className="blog-input min-h-[140px]" required />
+              </label>
+              <label className="grid gap-2 text-sm">
+                Tags (comma separated)
+                <input
+                  name="tags"
+                  value={formState.tags}
+                  onChange={handleFormChange}
+                  className="blog-input"
+                  placeholder="fantasy, writing, events"
+                />
+              </label>
+              <label className="grid gap-2 text-sm">
+                Featured image URL
+                <input
+                  name="featuredImage"
+                  value={formState.featuredImage}
+                  onChange={handleFormChange}
+                  className="blog-input"
+                  placeholder="https://..."
+                />
+              </label>
+              <button type="submit" className="w-full md:w-auto px-5 py-2 font-semibold blog-button">
+                Publish post
+              </button>
+            </form>
+          )}
         </div>
-      </div>
+      )}
+
+      {publishedShortStories.length > 0 && (
+        <div className="mb-10">
+          <h2 className="text-2xl font-semibold blog-heading mb-4">Short Stories</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {publishedShortStories.map((story) => (
+              <a
+                key={story.title}
+                href={story.url}
+                className="blog-card block p-5"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <p className="text-sm blog-muted">{story.type}</p>
+                <p className="text-lg font-semibold blog-heading">{story.title}</p>
+                <p className="text-sm mt-2">{story.description}</p>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
       <SearchBar
         value={search}
-        onChange={(e) => debouncedSetSearch(e.target.value)}
+        onChange={(event) => debouncedSetSearch(event.target.value)}
         aria-label="Search blog posts"
         placeholder="Search posts by title, summary, or tags..."
         className="mb-8"
       />
 
       {error && (
-        <p className="text-red-600 text-center mb-6" role="alert">
+        <p className="text-red-400 text-center mb-6" role="alert">
           {error}
         </p>
       )}
 
-      {isLoading ? (
-        <p className="text-center text-gray-500" aria-live="polite">
-          Loading posts...
-        </p>
-      ) : (
-        <div
-          className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 mt-6"
-          role="list"
-        >
-          {paginated.map((post) => (
-            <PostPreview
-              key={post.slug}
-              post={post}
-              className="transition-transform transform hover:scale-105"
-            />
-          ))}
-          {paginated.length === 0 && (
-            <p className="text-center text-gray-500 col-span-full mt-12" aria-live="polite">
-              No posts found.
-            </p>
-          )}
-        </div>
-      )}
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 mt-6" role="list">
+        {paginated.map((post) => (
+          <PostPreview key={post.slug} post={post} className="h-full" />
+        ))}
+        {paginated.length === 0 && (
+          <p className="text-center blog-muted col-span-full mt-12" aria-live="polite">
+            No posts found.
+          </p>
+        )}
+      </div>
 
       {totalPages > 1 && (
-        <Pagination
-          currentPage={page}
-          totalPages={totalPages}
-          onPageChange={(newPage) => setPage(newPage)}
-          className="mt-10"
-          aria-label="Blog pagination"
-        />
+        <Pagination currentPage={page} totalPages={totalPages} onPageChange={(newPage) => setPage(newPage)} className="mt-10" />
       )}
     </section>
   );
 }
-
-AuthorBlogPage.propTypes = {
-  posts: PropTypes.arrayOf(
-    PropTypes.shape({
-      slug: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      summary: PropTypes.string,
-      tags: PropTypes.arrayOf(PropTypes.string),
-    })
-  ),
-};

--- a/src/components/blog/BlogPost.jsx
+++ b/src/components/blog/BlogPost.jsx
@@ -1,8 +1,20 @@
-import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import ReactMarkdown from 'react-markdown';
-import { Heart, Share2, BookOpen, Clock, Tag, Twitter, Facebook, Linkedin, Copy, Check } from 'lucide-react';
-import AuthorBio from './AuthorBio';
+import React, { useEffect, useId, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import ReactMarkdown from "react-markdown";
+import {
+  Heart,
+  Share2,
+  BookOpen,
+  Clock,
+  Tag,
+  Twitter,
+  Facebook,
+  Linkedin,
+  Copy,
+  Check,
+} from "lucide-react";
+import AuthorBio from "./AuthorBio";
+import "./blog-theme.css";
 
 export default function BlogPost({ post, onLike, likeCount = 0, isLiked = false }) {
   const [liked, setLiked] = useState(isLiked);
@@ -12,194 +24,185 @@ export default function BlogPost({ post, onLike, likeCount = 0, isLiked = false 
   const [copySuccess, setCopySuccess] = useState(false);
   const [scrollProgress, setScrollProgress] = useState(0);
 
+  const shareMenuId = useId();
+
   // Calculate reading time
   useEffect(() => {
-    if (post?.body) {
-      const words = post.body.split(/\s+/).length;
-      const avgWPM = 200;
-      const time = Math.ceil(words / avgWPM);
-      setReadingTime(time);
-    }
+    if (!post?.body) return;
+    const words = post.body.split(/\s+/).filter(Boolean).length;
+    const avgWPM = 200;
+    setReadingTime(Math.max(1, Math.ceil(words / avgWPM)));
   }, [post?.body]);
 
-  // Track scroll progress
+  // Track scroll progress (smooth-ish, low overhead)
   useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY;
+    let raf = 0;
+
+    const update = () => {
+      const scrollTop = window.scrollY || 0;
       const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-      const progress = (scrollTop / docHeight) * 100;
-      setScrollProgress(Math.min(progress, 100));
+      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setScrollProgress(Math.min(Math.max(progress, 0), 100));
     };
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(update);
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    update();
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(raf);
+    };
   }, []);
+
+  // Close share menu on Escape
+  useEffect(() => {
+    if (!shareMenuOpen) return;
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") setShareMenuOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [shareMenuOpen]);
 
   if (!post || !post.title) {
     return (
-      <article className="prose mx-auto p-4 text-center text-red-600" role="alert">
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-          <p className="text-red-800 font-medium">Error: Invalid or missing post data.</p>
+      <main className="blog-shell min-h-[60vh] flex items-center justify-center px-4">
+        <div className="blog-surface p-8 max-w-md text-center" role="alert">
+          <h1 className="blog-title text-2xl mb-3">Error</h1>
+          <p className="blog-muted">Invalid or missing post data.</p>
         </div>
-      </article>
+      </main>
     );
   }
 
   const formattedDate = post.date
-    ? new Date(post.date).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
+    ? new Date(post.date).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
       })
-    : 'Date not available';
+    : "Date not available";
 
-  const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
+  const currentUrl = typeof window !== "undefined" ? window.location.href : "";
   const encodedUrl = encodeURIComponent(currentUrl);
   const encodedTitle = encodeURIComponent(post.title);
 
   const handleLike = () => {
     const newLiked = !liked;
     setLiked(newLiked);
-    setLikes(prev => newLiked ? prev + 1 : prev - 1);
-    if (onLike) onLike(newLiked);
+    setLikes((prev) => (newLiked ? prev + 1 : Math.max(0, prev - 1)));
+    onLike?.(newLiked);
   };
 
   const copyToClipboard = async () => {
     try {
       await navigator.clipboard.writeText(currentUrl);
       setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 2000);
+      window.setTimeout(() => setCopySuccess(false), 2000);
     } catch (err) {
-      console.error('Failed to copy URL:', err);
+      console.error("Failed to copy URL:", err);
     }
   };
 
-  const shareLinks = [
-    {
-      name: 'Twitter',
-      url: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
-      icon: Twitter,
-      color: 'hover:text-blue-400'
-    },
-    {
-      name: 'Facebook',
-      url: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
-      icon: Facebook,
-      color: 'hover:text-blue-600'
-    },
-    {
-      name: 'LinkedIn',
-      url: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-      icon: Linkedin,
-      color: 'hover:text-blue-700'
-    }
-  ];
+  const shareLinks = useMemo(
+    () => [
+      {
+        name: "Twitter",
+        url: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+        icon: Twitter,
+      },
+      {
+        name: "Facebook",
+        url: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+        icon: Facebook,
+      },
+      {
+        name: "LinkedIn",
+        url: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+        icon: Linkedin,
+      },
+    ],
+    [encodedTitle, encodedUrl]
+  );
 
   return (
-    <>
+    <div className="blog-shell">
       {/* Reading Progress Bar */}
-      <div className="fixed top-0 left-0 w-full h-1 bg-gray-200 dark:bg-gray-700 z-50">
-        <div 
-          className="h-full bg-gradient-to-r from-blue-500 to-purple-600 transition-all duration-300"
+      <div
+        className="fixed top-0 left-0 w-full h-1 blog-progress-track z-50"
+        role="progressbar"
+        aria-label="Reading progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(scrollProgress)}
+      >
+        <div
+          className="h-full blog-progress-bar transition-[width] duration-300"
           style={{ width: `${scrollProgress}%` }}
         />
       </div>
 
-      <article
-        className="max-w-4xl mx-auto bg-white dark:bg-gray-900 shadow-xl rounded-2xl overflow-hidden"
-        aria-labelledby="post-title"
-      >
+      <article className="max-w-4xl mx-auto blog-surface overflow-hidden" aria-labelledby="post-title">
         {/* Hero Section */}
         {post.featuredImage && (
           <div className="relative h-64 md:h-80 overflow-hidden">
-            <img 
-              src={post.featuredImage} 
-              alt={post.title}
-              className="w-full h-full object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+            <img src={post.featuredImage} alt={post.title} className="w-full h-full object-cover" />
+            <div className="absolute inset-0" style={{ background: "linear-gradient(to top, rgba(0,0,0,0.55), rgba(0,0,0,0))" }} />
           </div>
         )}
 
         <div className="p-6 md:p-8">
           {/* Header */}
           <header className="mb-8">
-            <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 dark:text-gray-400 mb-4">
-              <div className="flex items-center gap-1">
-                <Clock className="w-4 h-4" />
+            <div className="flex flex-wrap items-center gap-4 blog-meta mb-4">
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4" aria-hidden="true" />
                 <span>{readingTime} min read</span>
               </div>
-              <div className="flex items-center gap-1">
-                <BookOpen className="w-4 h-4" />
+              <div className="flex items-center gap-2">
+                <BookOpen className="w-4 h-4" aria-hidden="true" />
                 <span>{formattedDate}</span>
               </div>
             </div>
 
-            <h1 
-              id="post-title" 
-              className="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-white leading-tight mb-4"
-            >
+            <h1 id="post-title" className="blog-title text-3xl md:text-4xl lg:text-5xl leading-tight mb-4">
               {post.title}
             </h1>
 
-            {post.excerpt && (
-              <p className="text-lg text-gray-600 dark:text-gray-300 leading-relaxed">
-                {post.excerpt}
-              </p>
-            )}
+            {post.excerpt && <p className="blog-muted text-lg leading-relaxed">{post.excerpt}</p>}
           </header>
 
           {/* Author Bio */}
-          <AuthorBio className="mb-8 p-4 bg-gray-50 dark:bg-gray-800 rounded-xl" />
+          <div className="blog-surface p-4 mb-8">
+            <AuthorBio />
+          </div>
 
           {/* Main Content */}
-          <section className="prose prose-lg dark:prose-invert max-w-none">
+          <section className="blog-prose">
             {post.body ? (
-              <ReactMarkdown
-                components={{
-                  h1: ({children}) => <h1 className="text-2xl font-bold mt-8 mb-4 text-gray-900 dark:text-white">{children}</h1>,
-                  h2: ({children}) => <h2 className="text-xl font-semibold mt-6 mb-3 text-gray-800 dark:text-gray-100">{children}</h2>,
-                  h3: ({children}) => <h3 className="text-lg font-medium mt-4 mb-2 text-gray-700 dark:text-gray-200">{children}</h3>,
-                  p: ({children}) => <p className="mb-4 leading-relaxed text-gray-700 dark:text-gray-300">{children}</p>,
-                  blockquote: ({children}) => (
-                    <blockquote className="border-l-4 border-blue-500 pl-4 py-2 my-4 bg-blue-50 dark:bg-blue-900/20 italic">
-                      {children}
-                    </blockquote>
-                  ),
-                  code: ({children}) => (
-                    <code className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-sm font-mono">
-                      {children}
-                    </code>
-                  ),
-                  pre: ({children}) => (
-                    <pre className="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto my-4">
-                      {children}
-                    </pre>
-                  )
-                }}
-              >
-                {post.body}
-              </ReactMarkdown>
+              <ReactMarkdown>{post.body}</ReactMarkdown>
             ) : (
               <div className="text-center py-12">
-                <p className="text-gray-500 text-lg">No content available.</p>
+                <p className="blog-muted text-lg">No content available.</p>
               </div>
             )}
           </section>
 
           {/* Tags */}
           {post.tags?.length > 0 && (
-            <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
-              <div className="flex items-center gap-2 mb-3">
-                <Tag className="w-4 h-4 text-gray-500" />
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Tags</span>
+            <section className="mt-8 pt-6 blog-divider">
+              <div className="flex items-center gap-2 mb-3 blog-meta">
+                <Tag className="w-4 h-4" aria-hidden="true" />
+                <span className="text-sm font-medium">Tags</span>
               </div>
               <div className="flex flex-wrap gap-2">
-                {post.tags.map((tag, index) => (
-                  <span
-                    key={index}
-                    className="px-3 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full text-sm font-medium hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors cursor-pointer"
-                  >
+                {post.tags.map((tag) => (
+                  <span key={tag} className="blog-chip">
                     #{tag}
                   </span>
                 ))}
@@ -208,36 +211,38 @@ export default function BlogPost({ post, onLike, likeCount = 0, isLiked = false 
           )}
 
           {/* Action Bar */}
-          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <div className="mt-8 pt-6 blog-divider flex items-center justify-between">
             {/* Like Button */}
             <button
               onClick={handleLike}
-              className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-200 ${
-                liked 
-                  ? 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400' 
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700'
-              }`}
-              aria-label={liked ? 'Unlike post' : 'Like post'}
+              className={`blog-btn ${liked ? "blog-btn--liked" : ""} flex items-center gap-2`}
+              aria-label={liked ? "Unlike post" : "Like post"}
+              type="button"
             >
-              <Heart 
-                className={`w-5 h-5 transition-all duration-200 ${liked ? 'fill-current' : ''}`} 
-              />
+              <Heart className={`w-5 h-5 ${liked ? "fill-current" : ""}`} aria-hidden="true" />
               <span className="font-medium">{likes}</span>
             </button>
 
             {/* Share Menu */}
             <div className="relative">
               <button
-                onClick={() => setShareMenuOpen(!shareMenuOpen)}
-                className="flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 rounded-lg transition-colors"
+                onClick={() => setShareMenuOpen((v) => !v)}
+                className="blog-btn blog-btn--primary flex items-center gap-2"
                 aria-label="Share post"
+                aria-expanded={shareMenuOpen}
+                aria-controls={shareMenuId}
+                type="button"
               >
-                <Share2 className="w-5 h-5" />
+                <Share2 className="w-5 h-5" aria-hidden="true" />
                 <span className="font-medium">Share</span>
               </button>
 
               {shareMenuOpen && (
-                <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-10">
+                <div
+                  id={shareMenuId}
+                  className="absolute right-0 mt-2 w-56 blog-menu z-50"
+                  role="menu"
+                >
                   <div className="p-2">
                     {shareLinks.map((link) => (
                       <a
@@ -245,26 +250,30 @@ export default function BlogPost({ post, onLike, likeCount = 0, isLiked = false 
                         href={link.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`flex items-center gap-3 px-3 py-2 rounded-md transition-colors ${link.color} hover:bg-gray-50 dark:hover:bg-gray-700`}
+                        className="flex items-center gap-3 px-3 py-2 rounded-md transition-colors"
                         onClick={() => setShareMenuOpen(false)}
+                        role="menuitem"
                       >
-                        <link.icon className="w-4 h-4" />
+                        <link.icon className="w-4 h-4" aria-hidden="true" />
                         <span>{link.name}</span>
                       </a>
                     ))}
+
                     <button
                       onClick={() => {
                         copyToClipboard();
                         setShareMenuOpen(false);
                       }}
-                      className="flex items-center gap-3 px-3 py-2 rounded-md transition-colors hover:text-green-600 hover:bg-gray-50 dark:hover:bg-gray-700 w-full text-left"
+                      className="flex items-center gap-3 px-3 py-2 rounded-md transition-colors w-full text-left"
+                      type="button"
+                      role="menuitem"
                     >
                       {copySuccess ? (
-                        <Check className="w-4 h-4 text-green-600" />
+                        <Check className="w-4 h-4" aria-hidden="true" />
                       ) : (
-                        <Copy className="w-4 h-4" />
+                        <Copy className="w-4 h-4" aria-hidden="true" />
                       )}
-                      <span>{copySuccess ? 'Copied!' : 'Copy Link'}</span>
+                      <span>{copySuccess ? "Copied!" : "Copy Link"}</span>
                     </button>
                   </div>
                 </div>
@@ -276,12 +285,13 @@ export default function BlogPost({ post, onLike, likeCount = 0, isLiked = false 
 
       {/* Click outside to close share menu */}
       {shareMenuOpen && (
-        <div 
-          className="fixed inset-0 z-5" 
+        <div
+          className="fixed inset-0 z-40"
           onClick={() => setShareMenuOpen(false)}
+          aria-hidden="true"
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/components/blog/BlogPostWrapper.jsx
+++ b/src/components/blog/BlogPostWrapper.jsx
@@ -1,27 +1,25 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import posts from '../../data/posts.js';
 import BlogPost from './BlogPost';
 import SEO from '../utility/SEO';
+import './blog.css';
 
 export default function BlogPostWrapper() {
   const { slug } = useParams();
-  const navigate = useNavigate();
   const [post, setPost] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    // Simulate loading delay and find post
     const timer = setTimeout(() => {
       try {
-        const foundPost = posts.find((p) => p.slug === slug);
-        
+        const foundPost = posts.find((entry) => entry.slug === slug);
         if (!foundPost) {
           setError('Post not found');
-        } else {
-          setPost(foundPost);
+          return;
         }
+        setPost(foundPost);
       } catch (err) {
         setError('Error loading post');
         console.error('Error finding post:', err);
@@ -33,41 +31,29 @@ export default function BlogPostWrapper() {
     return () => clearTimeout(timer);
   }, [slug]);
 
-  // Loading state
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
-          <p className="text-lg text-gray-600">Loading post...</p>
+      <div className="min-h-screen flex items-center justify-center blog-shell">
+        <div className="text-center blog-card p-8">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[var(--color-antique-gold)] mx-auto mb-4" />
+          <p className="text-lg blog-muted">Loading post...</p>
         </div>
       </div>
     );
   }
 
-  // Error state
   if (error || !post) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center max-w-md mx-auto px-4">
-          <h1 className="text-6xl font-bold text-gray-300 mb-4">404</h1>
-          <h2 className="text-2xl font-semibold text-gray-800 mb-4">
-            Blog Post Not Found
-          </h2>
-          <p className="text-gray-600 mb-8">
-            The blog post you're looking for doesn't exist or may have been moved.
-          </p>
+      <div className="min-h-screen flex items-center justify-center blog-shell px-4">
+        <div className="text-center max-w-md mx-auto blog-surface p-8">
+          <h1 className="text-6xl font-bold blog-heading mb-4">404</h1>
+          <h2 className="text-2xl font-semibold blog-heading mb-4">Blog Post Not Found</h2>
+          <p className="blog-muted mb-8">The blog post you&apos;re looking for doesn&apos;t exist or may have been moved.</p>
           <div className="space-x-4">
-            <Link 
-              to="/blog" 
-              className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors"
-            >
+            <Link to="/blog" className="inline-block px-6 py-3 blog-button">
               Back to Blog
             </Link>
-            <Link 
-              to="/" 
-              className="inline-block bg-gray-600 text-white px-6 py-3 rounded-lg hover:bg-gray-700 transition-colors"
-            >
+            <Link to="/" className="inline-block px-6 py-3 blog-button--ghost rounded-md border border-[rgba(205,180,139,0.4)]">
               Home
             </Link>
           </div>
@@ -76,47 +62,32 @@ export default function BlogPostWrapper() {
     );
   }
 
-  // Success state
   return (
-    <div className="min-h-screen">
-      {/* SEO for individual post */}
-      <SEO 
-        title={`${post.title} - Melissa Michaels`}
-        description={post.excerpt || post.content?.substring(0, 160) || 'Blog post by Melissa Michaels'}
-      />
-      
-      {/* Navigation breadcrumb */}
+    <div className="min-h-screen blog-shell">
+      <SEO title={`${post.title} - Melissa Michaels`} description={post.excerpt || post.content?.substring(0, 160) || 'Blog post by Melissa Michaels'} />
+
       <nav className="container mx-auto px-4 py-6">
-        <div className="flex items-center space-x-2 text-sm text-gray-600">
-          <Link to="/" className="hover:text-blue-600 transition-colors">
+        <div className="flex items-center space-x-2 text-sm blog-muted">
+          <Link to="/" className="hover:text-[var(--color-accent)] transition-colors">
             Home
           </Link>
           <span>/</span>
-          <Link to="/blog" className="hover:text-blue-600 transition-colors">
+          <Link to="/blog" className="hover:text-[var(--color-accent)] transition-colors">
             Blog
           </Link>
           <span>/</span>
-          <span className="text-gray-800">{post.title}</span>
+          <span className="blog-heading">{post.title}</span>
         </div>
       </nav>
 
-      {/* Blog post content */}
       <BlogPost post={post} />
 
-      {/* Navigation to other posts */}
       <div className="container mx-auto px-4 py-8">
-        <div className="flex justify-between items-center border-t pt-8">
-          <Link 
-            to="/blog" 
-            className="inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors"
-          >
+        <div className="flex justify-between items-center border-t blog-divider pt-8">
+          <Link to="/blog" className="inline-flex items-center hover:text-[var(--color-accent)] transition-colors">
             ← Back to all posts
           </Link>
-          
-          {/* Optional: Add next/previous post navigation */}
-          <div className="text-sm text-gray-500">
-            Share this post
-          </div>
+          <div className="text-sm blog-muted">Share this post</div>
         </div>
       </div>
     </div>

--- a/src/components/blog/PostPreview.jsx
+++ b/src/components/blog/PostPreview.jsx
@@ -1,30 +1,28 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-export default function PostPreview({ post }) {
+export default function PostPreview({ post, className = '' }) {
   return (
-    <article className="bg-black/40 dark:bg-gray-100/20 p-6 rounded shadow hover:shadow-lg transition">
+    <article className={`blog-card p-6 ${className}`.trim()}>
       {post.thumbnail && (
         <Link to={`/blog/${post.slug}`} className="block mb-4">
           <img src={post.thumbnail} alt="" className="rounded" />
         </Link>
       )}
-      <h2 className="text-xl mb-2">
+      <h2 className="text-xl mb-2 blog-heading">
         <Link to={`/blog/${post.slug}`}>{post.title}</Link>
       </h2>
-      <p className="text-sm opacity-75 mb-4">
-        {new Date(post.date).toLocaleDateString()}
-      </p>
+      <p className="text-sm blog-muted mb-4">{new Date(post.date).toLocaleDateString()}</p>
       <p className="mb-2">{post.summary}</p>
       {post.tags && (
         <ul className="flex flex-wrap gap-2 mt-2">
           {post.tags.map((tag) => (
-            <li key={tag} className="text-xs bg-gray-700/50 px-2 py-1 rounded">
+            <li key={tag} className="text-xs px-2 py-1 rounded border border-[rgba(205,180,139,0.25)] bg-[rgba(205,180,139,0.1)]">
               {tag}
             </li>
           ))}
         </ul>
       )}
     </article>
-  )
+  );
 }

--- a/src/components/blog/blog-theme.css
+++ b/src/components/blog/blog-theme.css
@@ -1,0 +1,161 @@
+/* blog-theme.css — align blog UI with your gothic palette */
+
+.blog-shell {
+  color: var(--color-antique-gold);
+}
+
+.blog-surface {
+  background: rgba(2, 4, 8, 0.65);
+  border: 1px solid rgba(205, 180, 139, 0.18);
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.blog-title {
+  font-family: "Cinzel Decorative", serif;
+  color: var(--color-blood-red);
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
+}
+
+.blog-meta {
+  color: rgba(205, 180, 139, 0.75);
+  font-size: 0.95rem;
+}
+
+.blog-muted {
+  color: rgba(205, 180, 139, 0.75);
+}
+
+.blog-divider {
+  border-top: 1px solid rgba(205, 180, 139, 0.16);
+}
+
+.blog-progress-track {
+  background: rgba(205, 180, 139, 0.14);
+}
+
+.blog-progress-bar {
+  background: linear-gradient(90deg, var(--color-blood-red), var(--color-antique-gold));
+}
+
+.blog-btn {
+  border: 1px solid rgba(205, 180, 139, 0.22);
+  background: rgba(2, 4, 8, 0.55);
+  color: var(--color-antique-gold);
+  border-radius: 12px;
+  padding: 0.5rem 0.9rem;
+  transition: border-color 180ms ease, transform 180ms ease, background 180ms ease;
+}
+
+.blog-btn:hover {
+  border-color: rgba(185, 33, 29, 0.55);
+  transform: translateY(-1px);
+}
+
+.blog-btn--primary {
+  border-color: rgba(185, 33, 29, 0.6);
+  background: rgba(185, 33, 29, 0.2);
+  color: #fff;
+}
+
+.blog-btn--liked {
+  border-color: rgba(185, 33, 29, 0.7);
+  background: rgba(185, 33, 29, 0.25);
+  color: #fff;
+}
+
+.blog-chip {
+  border: 1px solid rgba(205, 180, 139, 0.22);
+  background: rgba(2, 4, 8, 0.5);
+  color: var(--color-antique-gold);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.8rem;
+  transition: border-color 180ms ease, background 180ms ease;
+}
+
+.blog-chip:hover {
+  border-color: rgba(185, 33, 29, 0.55);
+  background: rgba(185, 33, 29, 0.12);
+}
+
+.blog-menu {
+  background: rgba(10, 12, 18, 0.95);
+  border: 1px solid rgba(205, 180, 139, 0.18);
+  border-radius: 14px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.55);
+}
+
+.blog-menu a,
+.blog-menu button {
+  color: var(--color-antique-gold);
+}
+
+.blog-menu a:hover,
+.blog-menu button:hover {
+  background: rgba(185, 33, 29, 0.12);
+}
+
+/* Markdown styling (avoids tailwind "prose" dependency) */
+.blog-prose {
+  line-height: 1.75;
+  color: rgba(205, 180, 139, 0.92);
+}
+
+.blog-prose h1,
+.blog-prose h2,
+.blog-prose h3 {
+  font-family: "Cinzel Decorative", serif;
+  color: var(--color-antique-gold);
+  margin-top: 1.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.blog-prose h1 {
+  font-size: 1.6rem;
+}
+
+.blog-prose h2 {
+  font-size: 1.3rem;
+}
+
+.blog-prose h3 {
+  font-size: 1.1rem;
+}
+
+.blog-prose p {
+  margin: 0.9rem 0;
+}
+
+.blog-prose a {
+  color: var(--color-antique-gold);
+  text-decoration: underline;
+  text-decoration-color: rgba(185, 33, 29, 0.45);
+  text-underline-offset: 3px;
+}
+
+.blog-prose blockquote {
+  border-left: 3px solid rgba(185, 33, 29, 0.65);
+  padding: 0.75rem 1rem;
+  margin: 1.2rem 0;
+  background: rgba(185, 33, 29, 0.08);
+  border-radius: 12px;
+  font-style: italic;
+}
+
+.blog-prose code {
+  background: rgba(2, 4, 8, 0.7);
+  border: 1px solid rgba(205, 180, 139, 0.14);
+  padding: 0.1rem 0.35rem;
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+}
+
+.blog-prose pre {
+  background: rgba(2, 4, 8, 0.7);
+  border: 1px solid rgba(205, 180, 139, 0.14);
+  padding: 1rem;
+  border-radius: 14px;
+  overflow-x: auto;
+}

--- a/src/components/blog/blog.css
+++ b/src/components/blog/blog.css
@@ -1,0 +1,57 @@
+.blog-shell {
+  color: var(--color-base-100);
+}
+
+.blog-surface {
+  background: linear-gradient(180deg, rgba(9, 10, 14, 0.94), rgba(4, 5, 8, 0.94));
+  border: 1px solid rgba(205, 180, 139, 0.24);
+  border-radius: 1rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.blog-card {
+  background: linear-gradient(180deg, rgba(18, 20, 26, 0.92), rgba(10, 11, 14, 0.94));
+  border: 1px solid rgba(205, 180, 139, 0.2);
+  border-radius: 1rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(185, 33, 29, 0.45);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.34);
+}
+
+.blog-heading {
+  color: var(--color-antique-gold);
+}
+
+.blog-muted {
+  color: rgba(244, 241, 234, 0.72);
+}
+
+.blog-input {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(205, 180, 139, 0.3);
+  background: rgba(5, 6, 8, 0.78);
+  color: var(--color-base-100);
+  padding: 0.65rem 0.85rem;
+}
+
+.blog-button {
+  border-radius: 0.6rem;
+  border: 1px solid rgba(205, 180, 139, 0.4);
+  background: rgba(185, 33, 29, 0.9);
+  color: #fff;
+}
+
+.blog-button--ghost {
+  background: rgba(205, 180, 139, 0.14);
+  color: var(--color-antique-gold);
+}
+
+.blog-divider {
+  border-color: rgba(205, 180, 139, 0.2);
+}

--- a/src/components/utility/Pagination.jsx
+++ b/src/components/utility/Pagination.jsx
@@ -1,20 +1,29 @@
-import React from 'react'
+import React from 'react';
 
-export default function Pagination({ page, totalPages, onPageChange }) {
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
+export default function Pagination({ currentPage, totalPages, onPageChange, className = '' }) {
+  const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+
   return (
-    <nav className="flex justify-center gap-2 mt-8" aria-label="Pagination">
-      {pages.map((p) => (
-        <button
-          key={p}
-          onClick={() => onPageChange(p)}
-          className={`px-3 py-1 rounded ${
-            p === page ? 'bg-red-800 text-white' : 'bg-black/50'
-          }`}
-        >
-          {p}
-        </button>
-      ))}
+    <nav className={`flex justify-center gap-2 ${className}`.trim()} aria-label="Pagination">
+      {pages.map((pageNumber) => {
+        const isCurrent = pageNumber === currentPage;
+
+        return (
+          <button
+            key={pageNumber}
+            type="button"
+            onClick={() => onPageChange(pageNumber)}
+            aria-current={isCurrent ? 'page' : undefined}
+            className={`px-3 py-1 rounded-md border transition-colors ${
+              isCurrent
+                ? 'blog-button border-red-700'
+                : 'blog-button--ghost border-[rgba(205,180,139,0.35)] hover:bg-[rgba(205,180,139,0.22)]'
+            }`}
+          >
+            {pageNumber}
+          </button>
+        );
+      })}
     </nav>
-  )
+  );
 }

--- a/src/components/utility/SearchBar.jsx
+++ b/src/components/utility/SearchBar.jsx
@@ -1,13 +1,22 @@
-import React from 'react'
+import React from 'react';
 
-export default function SearchBar({ value, onChange }) {
+export default function SearchBar({
+  value,
+  onChange,
+  placeholder = 'Search posts...',
+  className = '',
+  'aria-label': ariaLabel = 'Search',
+  ...props
+}) {
   return (
     <input
       type="search"
-      placeholder="Search posts..."
       value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className="w-full mb-4 p-2 rounded bg-black/40 dark:bg-gray-100/20"
+      onChange={onChange}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      className={`blog-input ${className}`.trim()}
+      {...props}
     />
-  )
+  );
 }


### PR DESCRIPTION
### Motivation
- Replace the light/startup visual language with the site’s gothic blood-red / antique-gold palette and provide a shared theme for blog pages and components.
- Fix rendering and UX issues in the post view such as incorrect z-index, janky scroll progress, share overlay not closing on Escape, and inconsistent component contracts.
- Ensure local draft editing is gated to development and filter out placeholder short-story links so production lists only real items.

### Description
- Added `src/components/blog/blog-theme.css` and `src/components/blog/blog.css` to provide shared gothic tokens and classes (`.blog-shell`, `.blog-surface`, `.blog-title`, `.blog-prose`, `.blog-btn`, `.blog-chip`, `.blog-menu`, progress bar, etc.).
- Replaced `src/components/blog/BlogPost.jsx` with a themed implementation that removes light/dark Tailwind dependencies, avoids `z-5`, closes the share menu on `Escape`, and smooths reading-progress updates using `requestAnimationFrame` and a passive scroll listener while preserving like/share/copy/markdown behavior.
- Updated `src/components/blog/BlogPage.jsx` to gate local drafts behind `import.meta.env.DEV && VITE_ENABLE_LOCAL_DRAFTS === 'true'`, debounce search input, derive filtering/pagination as pure values, clamp page bounds, and filter `shortStories` to skip `example.com` placeholders; it also applies the new theme classes.
- Adjusted `BlogPostWrapper.jsx` and `PostPreview.jsx` to use the new theme classes and improve loading/error UIs, and extended `PostPreview` to accept a `className` prop for layout control.
- Standardized utility components: `src/components/utility/Pagination.jsx` now exposes `(currentPage, totalPages, onPageChange, className)` and uses `aria-current`, and `src/components/utility/SearchBar.jsx` accepts `placeholder`, `className`, `aria-label`, passthrough `...props` and uses a standard `onChange` signature.

### Testing
- Ran `npm test` and the test suite passed (`1 passed`).
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and it failed due to a pre-existing ESLint config issue (a global `AudioWorkletGlobalScope ` contains trailing whitespace), so lint fixes were not applied in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698533885f048329a8c740adf080cd3b)