### PR TITLE
Footer: correct Instagram handle to melissamdc104

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -16,7 +16,7 @@ const SOCIALS = [
   },
   {
     name: "Instagram",
-    href: "https://www.instagram.com/melssamdc104/",
+    href: "https://www.instagram.com/melissamdc104/",
     Icon: Instagram,
   },
 ];


### PR DESCRIPTION
One-character fix following up on #70: the Instagram URL was missing the "i" in "melissa".

`https://www.instagram.com/melssamdc104/` → `https://www.instagram.com/melissamdc104/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK)_