### PR TITLE
Footer: correct YouTube handle to @melissamichaelsurbanfantas6965

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -6,7 +6,7 @@ import "./footer.css";
 const SOCIALS = [
   {
     name: "YouTube",
-    href: "https://www.youtube.com/@melissamichaelsurbanfanas6965",
+    href: "https://www.youtube.com/@melissamichaelsurbanfantas6965",
     Icon: Youtube,
   },
   {


### PR DESCRIPTION
Follow-up to #70/#71: the YouTube URL was missing the "t" in "fantas".

`https://www.youtube.com/@melissamichaelsurbanfanas6965` → `https://www.youtube.com/@melissamichaelsurbanfantas6965`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK)_