### PR TITLE
Fix mobile horizontal overflow that hid the nav menu

### DIFF
--- a/src/components/newsletter/newsletter.css
+++ b/src/components/newsletter/newsletter.css
@@ -52,6 +52,9 @@
   border: 1px solid rgba(205, 180, 139, 0.16);
   border-radius: 1rem;
   padding: clamp(1.5rem, 3vw, 2.25rem);
+  /* the form fields slide in from x:+100px; clip that motion inside the panel
+     so it can't widen the page before the animation runs */
+  overflow-x: clip;
 }
 
 /* --- embedded newsletter card --- */

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@ html {
   background: var(--color-base-950);
   color: var(--color-base-100);
   font-family: var(--font-body);
+  /* body-only overflow-x is ignored by mobile browsers; clip on html too so
+     transformed/offscreen elements can't widen the page and hide the nav */
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* keep anchored sections clear of the fixed header when scrolled to */
@@ -63,6 +67,7 @@ body {
   background: radial-gradient(circle at top, rgba(12, 14, 20, 0.9), var(--color-base-950));
   min-height: 100vh;
   overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* anchor tags in antique gold with slight glow */


### PR DESCRIPTION
## Problem

On phones the page rendered ~545px wide in a 390px viewport, so you had to swipe left to even see the hamburger menu.

## Root cause

The contact form fields at the bottom of the homepage animate in from `x: +100px` (framer-motion). Until you scroll down and trigger that animation, the translated fields sit at 245–545px and stretch the whole document. `body { overflow-x: hidden }` was already set, but mobile browsers ignore it unless `html` is clipped too.

## Fix

- `newsletter.css`: `overflow-x: clip` on the contact panels so the slide-in animation is clipped inside its own card instead of widening the page
- `index.css`: add `overflow-x: hidden` + `overflow-x: clip` on `html` (and `clip` on `body`) as a general guard

## Verification

Rendered the built site in headless Chromium at 390×844 (mobile emulation):
- before: `document.scrollWidth` = 545px; after: **390px** at page top and after scrolling to the contact section
- hamburger menu visible and opens correctly; contact form still animates in and renders properly
- `npm run build` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01163B4b2avAagRUyiqowTsK)_