### PR TITLE
Redesign /blog as The Bloodborne Dispatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Melissa Michaels</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600&family=Cinzel+Decorative:wght@400;700;900&family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <a href="#main" class="skip-link">Skip to content</a>

--- a/src/components/blog/BlogPage.jsx
+++ b/src/components/blog/BlogPage.jsx
@@ -1,18 +1,137 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import PostPreview from './PostPreview';
-import SearchBar from '../utility/SearchBar';
-import Pagination from '../utility/Pagination';
-import { supabase, mapPost } from '../../lib/supabase';
+import { Link } from 'react-router-dom';
+import { Search, Clock, MessageCircle } from 'lucide-react';
 import { debounce } from 'lodash';
+import PostPreview from './PostPreview';
+import { readingMinutes } from '../../lib/readingTime';
+import SEO from '../utility/SEO';
+import { supabase, mapPost } from '../../lib/supabase';
+import './blog-page.css';
 
 const PER_PAGE = 6;
 
+function BulletinSignup() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState('idle'); // idle | submitting | success | error
+
+  const subscribe = async (e) => {
+    e.preventDefault();
+    const value = email.trim().toLowerCase();
+    if (!value) {
+      setStatus('error');
+      return;
+    }
+    setStatus('submitting');
+    // same edge function as the contact-section signup; it saves the
+    // subscriber and sends the confirmation email
+    const { data, error } = await supabase.functions.invoke('subscribe', {
+      body: { email: value, source: 'blog-dispatch' },
+    });
+    if (error || data?.error) {
+      console.error('Subscribe failed:', error || data?.error);
+      setStatus('error');
+    } else {
+      setStatus('success');
+      setEmail('');
+    }
+  };
+
+  return (
+    <section className="dispatch-bulletin" aria-label="Newsletter signup">
+      <div className="dispatch-bulletin-copy">
+        <p className="dispatch-eyebrow dispatch-eyebrow--rust">
+          Dispatches from editor E. Nocturne
+        </p>
+        <h3 className="dispatch-bulletin-title">Get the next field note first</h3>
+        <p className="dispatch-bulletin-sub">
+          Story clues, release news, and giveaways from inside the Chronicles.
+        </p>
+      </div>
+      {status === 'success' ? (
+        <p className="dispatch-bulletin-status" role="status">
+          Almost there — check your inbox and click the confirmation link.
+        </p>
+      ) : (
+        <form className="dispatch-bulletin-form" onSubmit={subscribe}>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="your@email.com"
+            aria-label="Email address"
+            required
+          />
+          <button type="submit" className="dispatch-btn" disabled={status === 'submitting'}>
+            {status === 'submitting' ? 'Joining…' : 'Subscribe'}
+          </button>
+        </form>
+      )}
+      {status === 'error' && (
+        <p className="dispatch-bulletin-status dispatch-bulletin-status--error" role="alert">
+          Something went wrong. Please try again.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function FeaturedDispatch({ post, commentCount }) {
+  const mins = readingMinutes(post.body);
+  const reports =
+    typeof commentCount === 'number'
+      ? `${commentCount} field report${commentCount === 1 ? '' : 's'}`
+      : null;
+
+  return (
+    <section className="dispatch-featured-wrap" aria-label="Latest dispatch">
+      <div className="dispatch-featured">
+        <div className="dispatch-featured-media">
+          {post.featuredImage ? (
+            <img src={post.featuredImage} alt="" />
+          ) : (
+            <div className="dispatch-media-placeholder">Featured image</div>
+          )}
+          <span className="dispatch-featured-badge">Latest dispatch</span>
+          <div className="dispatch-featured-bar" aria-hidden="true">
+            <span />
+          </div>
+        </div>
+        <div className="dispatch-featured-body">
+          {post.tags?.[0] && <p className="dispatch-kicker">{post.tags[0]}</p>}
+          <h2 className="dispatch-featured-title">
+            <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+          </h2>
+          <p className="dispatch-featured-excerpt">{post.summary}</p>
+          <div className="dispatch-meta">
+            <span>
+              <Clock size={15} aria-hidden="true" />
+              {mins} min read
+            </span>
+            {reports && (
+              <span>
+                <MessageCircle size={15} aria-hidden="true" />
+                {reports}
+              </span>
+            )}
+          </div>
+          <Link to={`/blog/${post.slug}`} className="dispatch-btn">
+            Read the dispatch →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function AuthorBlogPage() {
   const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
+  const [activeTag, setActiveTag] = useState('all');
+  const [newestFirst, setNewestFirst] = useState(true);
+  const [visible, setVisible] = useState(PER_PAGE);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [posts, setPosts] = useState([]);
+  const [commentCounts, setCommentCounts] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -43,11 +162,28 @@ export default function AuthorBlogPage() {
     return () => { cancelled = true; };
   }, []);
 
+  // visible comment tallies per post ("field reports")
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const { data, error: fetchError } = await supabase
+        .from('comments')
+        .select('post_slug')
+        .eq('hidden', false);
+      if (cancelled || fetchError || !data) return;
+      const counts = {};
+      for (const row of data) {
+        counts[row.post_slug] = (counts[row.post_slug] || 0) + 1;
+      }
+      setCommentCounts(counts);
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
   const debouncedSetSearch = useMemo(
-    () => debounce((value) => {
-      setSearch(value);
-      setPage(1);
-    }, 300),
+    () => debounce((value) => setSearch(value), 300),
     []
   );
 
@@ -55,79 +191,178 @@ export default function AuthorBlogPage() {
     return () => { debouncedSetSearch.cancel(); };
   }, [debouncedSetSearch]);
 
+  useEffect(() => {
+    setVisible(PER_PAGE);
+  }, [search, activeTag, newestFirst]);
+
+  const categories = useMemo(() => {
+    const counts = new Map();
+    for (const post of posts) {
+      for (const tag of post.tags || []) {
+        counts.set(tag, (counts.get(tag) || 0) + 1);
+      }
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+  }, [posts]);
+
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
-    if (!q) return posts;
-    return posts.filter((post) =>
-      post.title?.toLowerCase().includes(q) ||
-      post.summary?.toLowerCase().includes(q) ||
-      (post.tags || []).some((tag) => tag.toLowerCase().includes(q))
+    const matches = posts.filter((post) =>
+      (activeTag === 'all' || (post.tags || []).includes(activeTag)) &&
+      (!q ||
+        post.title?.toLowerCase().includes(q) ||
+        post.summary?.toLowerCase().includes(q) ||
+        (post.tags || []).some((tag) => tag.toLowerCase().includes(q)))
     );
-  }, [posts, search]);
+    return matches.sort((a, b) =>
+      newestFirst
+        ? new Date(b.date) - new Date(a.date)
+        : new Date(a.date) - new Date(b.date)
+    );
+  }, [posts, search, activeTag, newestFirst]);
 
-  const paginated = useMemo(() => {
-    const start = (page - 1) * PER_PAGE;
-    return filtered.slice(start, start + PER_PAGE);
-  }, [filtered, page]);
-
-  const totalPages = Math.ceil(filtered.length / PER_PAGE);
+  // the newest post headlines as "Latest dispatch" while no filters are active
+  const featured = !search && activeTag === 'all' && posts.length > 0 ? posts[0] : null;
+  const gridPosts = featured
+    ? filtered.filter((post) => post.slug !== featured.slug)
+    : filtered;
+  const shown = gridPosts.slice(0, visible);
+  const countFor = (post) => (commentCounts ? commentCounts[post.slug] ?? 0 : undefined);
 
   return (
-    <section className="max-w-5xl mx-auto px-4 py-10" aria-labelledby="blog-title">
-      <header className="mb-10">
-        <p className="blog-meta mb-2">From the desk of Melissa Michaels</p>
-        <h1 id="blog-title" className="text-4xl mb-1">
-          The Bloodborne Dispatch
-        </h1>
-        <hr className="blog-rule" aria-hidden="true" />
-        <p className="mt-4 opacity-80 max-w-2xl">
-          Field notes on writing, the Bloodborne Chronicles, and the shadows in
-          between — collected from a decade at the keyboard.
-        </p>
-      </header>
+    <div className="dispatch-page">
+      <SEO
+        title="The Bloodborne Dispatch — Melissa Michaels"
+        description="Field notes on writing, the Bloodborne Chronicles, and the shadows in between — collected from a decade at the keyboard."
+      />
+      <div className="dispatch-frame">
 
-      <div className="mb-8">
-        <SearchBar
-          onChange={(value) => debouncedSetSearch(value)}
-          aria-label="Search blog posts"
-          placeholder="Search posts by title, summary, or tags..."
-        />
+        <header className="dispatch-masthead">
+          <div className="dispatch-masthead-row">
+            <div className="dispatch-masthead-title">
+              <p className="dispatch-eyebrow">From the desk of Melissa Michaels</p>
+              <h1 className="dispatch-title">The Bloodborne Dispatch</h1>
+              <hr className="dispatch-rule" aria-hidden="true" />
+              <p className="dispatch-tagline">
+                Field notes on writing, the Bloodborne Chronicles, and the shadows in
+                between — collected from a decade at the keyboard.
+              </p>
+            </div>
+            <label className="dispatch-search">
+              <Search size={18} color="rgba(205,180,139,.7)" aria-hidden="true" />
+              <input
+                type="search"
+                placeholder="Search dispatches…"
+                aria-label="Search dispatches"
+                onChange={(e) => debouncedSetSearch(e.target.value)}
+              />
+            </label>
+          </div>
+          <nav className="dispatch-filters" aria-label="Post categories">
+            <button
+              type="button"
+              className={`dispatch-chip ${activeTag === 'all' ? 'dispatch-chip--active' : ''}`}
+              onClick={() => setActiveTag('all')}
+            >
+              All · {posts.length}
+            </button>
+            {categories.map(([tag, count]) => (
+              <button
+                key={tag}
+                type="button"
+                className={`dispatch-chip ${activeTag === tag ? 'dispatch-chip--active' : ''}`}
+                onClick={() => setActiveTag(activeTag === tag ? 'all' : tag)}
+              >
+                {tag} · {count}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="dispatch-sort"
+              onClick={() => setNewestFirst((v) => !v)}
+            >
+              Sort: {newestFirst ? 'Newest first ▾' : 'Oldest first ▴'}
+            </button>
+          </nav>
+        </header>
+
+        {error && (
+          <p className="dispatch-status dispatch-status--error" role="alert">
+            {error}
+          </p>
+        )}
+
+        {isLoading ? (
+          <p className="dispatch-status" aria-live="polite">
+            Consulting the archives…
+          </p>
+        ) : (
+          <>
+            {featured && (
+              <FeaturedDispatch post={featured} commentCount={countFor(featured)} />
+            )}
+
+            <BulletinSignup />
+
+            <section className="dispatch-grid-wrap" aria-label="All dispatches">
+              {shown.length > 0 ? (
+                <div className="dispatch-grid" role="list">
+                  {shown.map((post) => (
+                    <PostPreview key={post.slug} post={post} commentCount={countFor(post)} />
+                  ))}
+                </div>
+              ) : (
+                !featured &&
+                !error && (
+                  <p className="dispatch-status" aria-live="polite">
+                    No dispatches match — the shadows are keeping them for now.
+                  </p>
+                )
+              )}
+            </section>
+
+            <section className="dispatch-book-wrap" aria-label="Related book">
+              <div className="dispatch-book">
+                <div className="dispatch-book-cover">
+                  <img
+                    src={`${import.meta.env.BASE_URL}RR_Cover.jpg`}
+                    alt="Raven's Revenge book cover"
+                    loading="lazy"
+                  />
+                </div>
+                <div>
+                  <p className="dispatch-eyebrow dispatch-eyebrow--rust">
+                    This dispatch connects to
+                  </p>
+                  <h3 className="dispatch-book-title">Raven&apos;s Revenge</h3>
+                  <p className="dispatch-book-sub">
+                    Book One of The Bloodborne Chronicles — where the thermal-vision
+                    field notes become the story.
+                  </p>
+                </div>
+                <Link to="/#services" className="dispatch-btn">
+                  Read a sample
+                </Link>
+              </div>
+            </section>
+
+            <div className="dispatch-loadmore">
+              {gridPosts.length > visible && (
+                <button
+                  type="button"
+                  className="dispatch-btn dispatch-btn--ghost"
+                  onClick={() => setVisible((v) => v + PER_PAGE)}
+                >
+                  Load more dispatches
+                </button>
+              )}
+              <p className="dispatch-loadmore-note">
+                Join the discussion — readers leave field reports on every dispatch.
+              </p>
+            </div>
+          </>
+        )}
       </div>
-
-      {error && (
-        <p className="text-red-500 text-center mb-6" role="alert">
-          {error}
-        </p>
-      )}
-
-      {isLoading ? (
-        <p className="text-center opacity-70" aria-live="polite">
-          Loading posts...
-        </p>
-      ) : (
-        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 mt-6" role="list">
-          {paginated.map((post) => (
-            <PostPreview
-              key={post.slug}
-              post={post}
-              className="transition-transform transform hover:scale-105"
-            />
-          ))}
-          {paginated.length === 0 && (
-            <p className="text-center opacity-70 col-span-full mt-12" aria-live="polite">
-              No posts found.
-            </p>
-          )}
-        </div>
-      )}
-
-      {totalPages > 1 && (
-        <Pagination
-          page={page}
-          totalPages={totalPages}
-          onPageChange={(newPage) => setPage(newPage)}
-        />
-      )}
-    </section>
+    </div>
   );
 }

--- a/src/components/blog/BlogPage.jsx
+++ b/src/components/blog/BlogPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Search, Clock, MessageCircle } from 'lucide-react';
 import { debounce } from 'lodash';
 import PostPreview from './PostPreview';
+import DispatchThumb from './DispatchThumb';
 import { readingMinutes } from '../../lib/readingTime';
 import SEO from '../utility/SEO';
 import { supabase, mapPost } from '../../lib/supabase';
@@ -89,7 +90,7 @@ function FeaturedDispatch({ post, commentCount }) {
           {post.featuredImage ? (
             <img src={post.featuredImage} alt="" />
           ) : (
-            <div className="dispatch-media-placeholder">Featured image</div>
+            <DispatchThumb slug={post.slug} title={post.title} />
           )}
           <span className="dispatch-featured-badge">Latest dispatch</span>
           <div className="dispatch-featured-bar" aria-hidden="true">

--- a/src/components/blog/DispatchThumb.jsx
+++ b/src/components/blog/DispatchThumb.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+
+// Deterministic per-post fallback art for posts without a featured image.
+// Seeded by slug so a post keeps the same look across renders and pages.
+
+const VARIANTS = [
+  { glow: '#B9211D', gx: '20%', gy: '15%' },
+  { glow: '#8C5431', gx: '80%', gy: '20%' },
+  { glow: '#B9211D', gx: '75%', gy: '80%' },
+  { glow: '#6e0f0c', gx: '25%', gy: '75%' },
+  { glow: '#8C5431', gx: '50%', gy: '10%' },
+  { glow: '#6e0f0c', gx: '15%', gy: '55%' },
+]
+
+function hashCode(str = '') {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+export default function DispatchThumb({ slug = '', title = '' }) {
+  const variant = VARIANTS[hashCode(slug) % VARIANTS.length]
+  const letter = (title.match(/[a-zA-Z0-9]/) || ['✦'])[0].toUpperCase()
+  const gradientId = `dispatch-thumb-${slug}`
+
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 400 240"
+      preserveAspectRatio="xMidYMid slice"
+      role="img"
+      aria-hidden="true"
+      style={{ display: 'block' }}
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stopColor="#1B0C00" />
+          <stop offset="1" stopColor="#0d1014" />
+        </linearGradient>
+        <radialGradient id={`${gradientId}-glow`} cx={variant.gx} cy={variant.gy} r="70%">
+          <stop offset="0" stopColor={variant.glow} stopOpacity="0.32" />
+          <stop offset="1" stopColor={variant.glow} stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="400" height="240" fill={`url(#${gradientId})`} />
+      <rect width="400" height="240" fill={`url(#${gradientId}-glow)`} />
+      <text
+        x="200"
+        y="120"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontFamily="'Cinzel Decorative', serif"
+        fontWeight="900"
+        fontSize="150"
+        fill="#CDB48B"
+        opacity="0.16"
+      >
+        {letter}
+      </text>
+      <g stroke="#CDB48B" strokeOpacity="0.35" strokeWidth="1" fill="none">
+        <path d="M170 200 h24 m12 0 h24" />
+        <path d="M200 194 l6 6 l-6 6 l-6 -6 z" fill="#B9211D" fillOpacity="0.55" stroke="none" />
+      </g>
+    </svg>
+  )
+}

--- a/src/components/blog/PostPreview.jsx
+++ b/src/components/blog/PostPreview.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { Clock, MessageCircle } from 'lucide-react'
 import { readingMinutes } from '../../lib/readingTime'
+import DispatchThumb from './DispatchThumb'
 
 export default function PostPreview({ post, commentCount }) {
   const kickerDate = post.date
@@ -20,7 +21,7 @@ export default function PostPreview({ post, commentCount }) {
         {post.featuredImage ? (
           <img src={post.featuredImage} alt="" loading="lazy" />
         ) : (
-          <div className="dispatch-media-placeholder">Thumbnail</div>
+          <DispatchThumb slug={post.slug} title={post.title} />
         )}
       </Link>
       <div className="dispatch-card-body">

--- a/src/components/blog/PostPreview.jsx
+++ b/src/components/blog/PostPreview.jsx
@@ -1,40 +1,47 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { Clock, MessageCircle } from 'lucide-react'
+import { readingMinutes } from '../../lib/readingTime'
 
-export default function PostPreview({ post }) {
-  const formattedDate = post.date
-    ? new Date(post.date).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
+export default function PostPreview({ post, commentCount }) {
+  const kickerDate = post.date
+    ? new Date(post.date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
     : null
+  const tag = post.tags?.[0]
 
   return (
-    <article className="blog-card flex flex-col p-6">
-      {post.thumbnail && (
-        <Link to={`/blog/${post.slug}`} className="block mb-4 -mt-2 -mx-2">
-          <img src={post.thumbnail} alt="" className="rounded-lg w-full object-cover max-h-44" />
-        </Link>
-      )}
-      {formattedDate && <p className="blog-meta mb-2">{formattedDate}</p>}
-      <h2 className="text-xl mb-3 leading-snug">
-        <Link to={`/blog/${post.slug}`}>{post.title}</Link>
-      </h2>
-      <p className="text-sm opacity-80 mb-4 line-clamp-4">{post.summary}</p>
-      <div className="mt-auto flex items-end justify-between gap-3">
-        <Link to={`/blog/${post.slug}`} className="blog-meta hover:opacity-100">
-          Read the dispatch →
-        </Link>
-        {post.tags?.length > 0 && (
-          <ul className="flex flex-wrap gap-2 justify-end">
-            {post.tags.map((tag) => (
-              <li key={tag} className="blog-chip text-xs px-2 py-1 rounded-full">
-                {tag}
-              </li>
-            ))}
-          </ul>
+    <article className="dispatch-card">
+      <Link
+        to={`/blog/${post.slug}`}
+        className="dispatch-card-media"
+        aria-hidden="true"
+        tabIndex={-1}
+      >
+        {post.featuredImage ? (
+          <img src={post.featuredImage} alt="" loading="lazy" />
+        ) : (
+          <div className="dispatch-media-placeholder">Thumbnail</div>
         )}
+      </Link>
+      <div className="dispatch-card-body">
+        <p className="dispatch-card-kicker">{[tag, kickerDate].filter(Boolean).join(' · ')}</p>
+        <h3 className="dispatch-card-title">
+          <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+        </h3>
+        <p className="dispatch-card-excerpt">{post.summary}</p>
+        <div className="dispatch-card-footer">
+          <span>
+            <Clock size={12} aria-hidden="true" />
+            {readingMinutes(post.body)} min
+          </span>
+          {typeof commentCount === 'number' && (
+            <span>
+              <MessageCircle size={12} aria-hidden="true" />
+              {commentCount}
+            </span>
+          )}
+          {tag && <span className="dispatch-card-tag">{tag}</span>}
+        </div>
       </div>
     </article>
   )

--- a/src/components/blog/blog-page.css
+++ b/src/components/blog/blog-page.css
@@ -209,20 +209,6 @@
   pointer-events: none;
 }
 
-.dispatch-media-placeholder {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, var(--color-burgundy), var(--color-base-900));
-  font-family: "Inter", sans-serif;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(205, 180, 139, 0.4);
-}
-
 .dispatch-featured-badge {
   position: absolute;
   top: 18px;
@@ -429,10 +415,6 @@
   object-fit: cover;
   display: block;
 }
-.dispatch-card-media .dispatch-media-placeholder {
-  font-size: 11px;
-}
-
 .dispatch-card-body {
   padding: 22px;
   display: flex;

--- a/src/components/blog/blog-page.css
+++ b/src/components/blog/blog-page.css
@@ -1,0 +1,609 @@
+/* blog-page.css — The Bloodborne Dispatch (blog index) */
+
+.dispatch-page {
+  font-family: var(--font-body);
+  min-height: 100vh;
+  padding: clamp(20px, 4vw, 56px) clamp(16px, 4vw, 40px) 72px;
+}
+
+.dispatch-frame {
+  max-width: 1180px;
+  margin: 0 auto;
+  border: 1px solid rgba(205, 180, 139, 0.18);
+  border-radius: 14px;
+  overflow: hidden;
+  background: radial-gradient(circle at top, rgba(12, 14, 20, 0.9), var(--color-base-950));
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+}
+
+/* ---- masthead -------------------------------------------------------- */
+.dispatch-masthead {
+  padding: 52px clamp(24px, 4vw, 56px) 34px;
+  border-bottom: 1px solid rgba(205, 180, 139, 0.12);
+}
+
+.dispatch-masthead-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+}
+
+.dispatch-masthead-title {
+  max-width: 640px;
+}
+
+.dispatch-eyebrow {
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: rgba(205, 180, 139, 0.8);
+  margin: 0 0 12px;
+}
+
+.dispatch-title {
+  font-family: var(--font-display);
+  font-weight: 900;
+  color: var(--color-accent);
+  font-size: clamp(34px, 4.4vw, 52px);
+  line-height: 1.04;
+  margin: 0;
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.75);
+}
+
+.dispatch-rule {
+  width: 72px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--color-accent), transparent);
+  border: none;
+  margin: 16px 0 0;
+}
+
+.dispatch-tagline {
+  font-family: var(--font-serif);
+  color: #cfc4b2;
+  font-size: 18px;
+  line-height: 1.55;
+  margin: 16px 0 0;
+}
+
+.dispatch-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(5, 6, 7, 0.7);
+  border: 1px solid rgba(205, 180, 139, 0.25);
+  border-radius: 10px;
+  padding: 12px 16px;
+  min-width: 260px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.dispatch-search:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 18px var(--color-accent-soft);
+}
+.dispatch-search svg {
+  flex-shrink: 0;
+}
+.dispatch-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  font-family: "Inter", sans-serif;
+  color: var(--color-antique-gold);
+  font-size: 14px;
+  min-width: 0;
+}
+.dispatch-search input::placeholder {
+  color: rgba(205, 180, 139, 0.5);
+}
+.dispatch-search input:focus {
+  outline: none;
+}
+
+/* ---- category chips + sort ------------------------------------------ */
+.dispatch-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.dispatch-chip {
+  font-family: "Inter", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  padding: 7px 16px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-antique-gold);
+  border: 1px solid rgba(205, 180, 139, 0.3);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+.dispatch-chip:hover {
+  border-color: var(--color-accent);
+}
+.dispatch-chip--active {
+  background: var(--color-accent);
+  color: #0a0705;
+  border-color: var(--color-accent);
+}
+
+.dispatch-sort {
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  color: rgba(205, 180, 139, 0.55);
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 7px 0;
+  transition: color 0.2s ease;
+}
+.dispatch-sort:hover {
+  color: var(--color-antique-gold);
+}
+
+/* ---- shared buttons --------------------------------------------------- */
+.dispatch-btn {
+  font-family: var(--font-accent);
+  font-size: 15px;
+  padding: 12px 24px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--color-accent), #6e0f0c);
+  color: var(--color-antique-gold);
+  border: 1px solid var(--color-antique-gold);
+  cursor: pointer;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
+}
+.dispatch-btn:hover {
+  color: var(--color-antique-gold);
+  filter: brightness(1.15);
+  box-shadow: 0 0 18px var(--color-accent-soft);
+}
+
+.dispatch-btn--ghost {
+  background: rgba(205, 180, 139, 0.08);
+  border: 1px solid rgba(205, 180, 139, 0.3);
+  padding: 13px 32px;
+}
+.dispatch-btn--ghost:hover {
+  border-color: var(--color-accent);
+}
+
+/* ---- featured dispatch ------------------------------------------------ */
+.dispatch-featured-wrap {
+  padding: 40px clamp(24px, 4vw, 56px) 30px;
+}
+
+.dispatch-featured {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  border: 1px solid rgba(205, 180, 139, 0.16);
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(165deg, var(--color-base-900), var(--color-base-950));
+}
+
+.dispatch-featured-media {
+  position: relative;
+  height: 360px;
+  border-right: 1px solid rgba(205, 180, 139, 0.1);
+}
+.dispatch-featured-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.dispatch-featured-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(185, 33, 29, 0.14), transparent 55%);
+  pointer-events: none;
+}
+
+.dispatch-media-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-burgundy), var(--color-base-900));
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(205, 180, 139, 0.4);
+}
+
+.dispatch-featured-badge {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  font-family: var(--font-accent);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  background: var(--color-accent);
+  color: #0a0705;
+  border-radius: 4px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+  z-index: 1;
+}
+
+.dispatch-featured-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 4px;
+  background: rgba(5, 6, 7, 0.6);
+  z-index: 1;
+}
+.dispatch-featured-bar span {
+  display: block;
+  width: 38%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-accent), #6e0f0c);
+}
+
+.dispatch-featured-body {
+  padding: 38px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.dispatch-kicker {
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: rgba(205, 180, 139, 0.8);
+  margin: 0 0 14px;
+}
+
+.dispatch-featured-title {
+  font-family: var(--font-display);
+  color: var(--color-antique-gold);
+  font-size: 30px;
+  line-height: 1.15;
+  margin: 0 0 14px;
+  text-shadow: none;
+}
+.dispatch-featured-title a {
+  color: inherit;
+}
+
+.dispatch-featured-excerpt {
+  font-family: var(--font-serif);
+  color: #cfc4b2;
+  font-size: 18px;
+  line-height: 1.6;
+  margin: 0 0 22px;
+}
+
+.dispatch-meta {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 24px;
+  font-family: "Inter", sans-serif;
+  font-size: 13px;
+  color: rgba(205, 180, 139, 0.75);
+}
+.dispatch-meta span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: rgba(205, 180, 139, 0.75);
+}
+
+.dispatch-featured .dispatch-btn {
+  align-self: flex-start;
+}
+
+/* ---- bulletin (newsletter capture) ------------------------------------ */
+.dispatch-bulletin {
+  margin: 14px clamp(24px, 4vw, 56px) 34px;
+  padding: 30px 34px;
+  border: 1px solid rgba(205, 180, 139, 0.28);
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(27, 12, 0, 0.9), rgba(53, 19, 4, 0.95));
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 22px;
+}
+
+.dispatch-bulletin-copy {
+  max-width: 520px;
+}
+
+.dispatch-eyebrow--rust {
+  letter-spacing: 0.2em;
+  font-size: 11px;
+  color: var(--color-russet);
+  margin: 0 0 8px;
+}
+
+.dispatch-bulletin-title {
+  font-family: var(--font-display);
+  color: var(--color-antique-gold);
+  font-size: 24px;
+  margin: 0 0 6px;
+  text-shadow: none;
+}
+
+.dispatch-bulletin-sub {
+  font-family: var(--font-serif);
+  color: #cfc4b2;
+  font-size: 17px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.dispatch-bulletin-form {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+  min-width: 280px;
+  max-width: 420px;
+}
+.dispatch-bulletin-form input {
+  flex: 1;
+  font-family: "Inter", sans-serif;
+  font-size: 15px;
+  padding: 13px 16px;
+  background: rgba(205, 180, 139, 0.1);
+  border: 1px solid var(--color-russet);
+  border-radius: 8px;
+  color: var(--color-antique-gold);
+  min-width: 0;
+}
+.dispatch-bulletin-form input::placeholder {
+  color: var(--color-russet);
+}
+.dispatch-bulletin-form input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 18px var(--color-accent-soft);
+}
+.dispatch-bulletin-form .dispatch-btn {
+  padding: 13px 22px;
+}
+
+.dispatch-bulletin-status {
+  font-family: var(--font-serif);
+  font-size: 17px;
+  color: var(--color-antique-gold);
+  margin: 0;
+}
+.dispatch-bulletin-status--error {
+  color: #f08a86;
+}
+
+/* ---- dispatch grid ----------------------------------------------------- */
+.dispatch-grid-wrap {
+  padding: 0 clamp(24px, 4vw, 56px) 8px;
+}
+
+.dispatch-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.dispatch-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(205, 180, 139, 0.16);
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(165deg, var(--color-base-900), var(--color-base-950));
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.dispatch-card:hover,
+.dispatch-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(185, 33, 29, 0.55);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.55), 0 0 28px var(--color-accent-soft);
+}
+
+.dispatch-card-media {
+  height: 170px;
+  display: block;
+}
+.dispatch-card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.dispatch-card-media .dispatch-media-placeholder {
+  font-size: 11px;
+}
+
+.dispatch-card-body {
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.dispatch-card-kicker {
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: rgba(205, 180, 139, 0.8);
+  margin: 0 0 10px;
+}
+
+.dispatch-card-title {
+  font-family: var(--font-display);
+  color: var(--color-antique-gold);
+  font-size: 19px;
+  line-height: 1.3;
+  margin: 0 0 10px;
+  text-shadow: none;
+}
+.dispatch-card-title a {
+  color: inherit;
+}
+.dispatch-card-title a:hover {
+  color: var(--color-accent);
+}
+
+.dispatch-card-excerpt {
+  font-family: var(--font-serif);
+  color: #b9ad9b;
+  font-size: 16px;
+  line-height: 1.5;
+  margin: 0 0 18px;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.dispatch-card-footer {
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid rgba(205, 180, 139, 0.12);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-family: "Inter", sans-serif;
+  font-size: 11px;
+  color: rgba(205, 180, 139, 0.7);
+}
+.dispatch-card-footer span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.dispatch-card-tag {
+  margin-left: auto;
+  color: var(--color-antique-gold);
+  border: 1px solid rgba(185, 33, 29, 0.4);
+  background: var(--color-accent-soft);
+  border-radius: 999px;
+  padding: 3px 9px;
+}
+
+/* ---- book tie-in ------------------------------------------------------- */
+.dispatch-book-wrap {
+  padding: 34px clamp(24px, 4vw, 56px);
+}
+
+.dispatch-book {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) auto;
+  gap: 26px;
+  align-items: center;
+  border: 1px solid rgba(205, 180, 139, 0.2);
+  border-radius: 14px;
+  padding: 24px 28px;
+  background: linear-gradient(135deg, var(--color-black), var(--color-burgundy));
+}
+
+.dispatch-book-cover {
+  aspect-ratio: 2 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-chocolate), var(--color-base-900));
+  border-radius: 5px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.dispatch-book-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.dispatch-book-title {
+  font-family: var(--font-display);
+  color: var(--color-antique-gold);
+  font-size: 24px;
+  margin: 0 0 8px;
+  text-shadow: none;
+}
+
+.dispatch-book-sub {
+  font-family: var(--font-serif);
+  color: #cfc4b2;
+  font-size: 17px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ---- load more / status ------------------------------------------------ */
+.dispatch-loadmore {
+  padding: 6px 0 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.dispatch-loadmore-note {
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: rgba(205, 180, 139, 0.55);
+  margin: 0;
+}
+
+.dispatch-status {
+  padding: 48px clamp(24px, 4vw, 56px);
+  text-align: center;
+  font-family: var(--font-serif);
+  font-size: 18px;
+  color: rgba(205, 180, 139, 0.7);
+}
+.dispatch-status--error {
+  color: #f08a86;
+}
+
+/* ---- responsive -------------------------------------------------------- */
+@media (max-width: 880px) {
+  .dispatch-featured {
+    grid-template-columns: 1fr;
+  }
+  .dispatch-featured-media {
+    height: 240px;
+    border-right: none;
+    border-bottom: 1px solid rgba(205, 180, 139, 0.1);
+  }
+  .dispatch-featured-body {
+    padding: 28px 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .dispatch-book {
+    grid-template-columns: 90px minmax(0, 1fr);
+  }
+  .dispatch-book .dispatch-btn {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+  .dispatch-meta {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,8 @@
 
   --font-display: "Cinzel Decorative", serif;
   --font-body: "Inter", "Cinzel Decorative", serif;
+  --font-serif: "Cormorant Garamond", Georgia, serif;
+  --font-accent: "Cinzel", serif;
 
   /* Legacy palette compatibility */
   --color-black: #010800;

--- a/src/lib/readingTime.js
+++ b/src/lib/readingTime.js
@@ -1,0 +1,5 @@
+// Rough reading time from the raw markdown body, same 200 wpm as BlogPost.
+export function readingMinutes(body = '') {
+  const words = body.trim() ? body.trim().split(/\s+/).length : 0
+  return Math.max(1, Math.ceil(words / 200))
+}


### PR DESCRIPTION
## Summary

Implements the agreed **Bloodborne Dispatch** design as the blog index page.

- **Masthead** — eyebrow, display title, gradient rule, tagline, search box, category chips derived from post tags with live counts, and a newest/oldest sort toggle
- **Featured card** — the newest post headlines as "Latest dispatch" (steps aside while searching/filtering)
- **Newsletter capture** — inline "editor E. Nocturne" banner wired to the existing `subscribe` edge function (`source: blog-dispatch`)
- **Dispatch cards** — thumbnail, `Tag · Mon YYYY` kicker, serif excerpt, footer with read time, comment count ("field reports"), and tag chip
- **Book tie-in** — Raven's Revenge banner using the real cover art, linking to the homepage book section
- **Load more** — replaces numeric pagination
- **Fonts** — loads Cinzel, Cinzel Decorative, Cormorant Garamond, and Inter from Google Fonts; the theme referenced these families but never loaded them, so this also fixes typography site-wide

## Notes

- Category chips currently show only "All · 45" because no posts have tags yet; chips appear automatically as posts get tagged
- Verified locally against the live Supabase data: search, filter, sort, load-more, and comment counts all working; responsive at mobile widths; `npm test` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)